### PR TITLE
Pre-init s2i extensibility

### DIFF
--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -55,6 +55,7 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.co
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
     mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
+    mkdir -p /usr/share/container-scripts/nginx/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx110 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -29,8 +29,10 @@ LABEL summary="$SUMMARY" \
       version="1.10" \
       release="1"
 
-ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d
-ENV NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d
+ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=/opt/app-root/
 
 RUN yum install -y yum-utils gettext hostname && \
     yum install -y centos-release-scl-rh epel-release && \
@@ -52,6 +54,7 @@ COPY ./root/ /
 RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.conf && \
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
+    mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx110 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.10/Dockerfile.rhel7
+++ b/1.10/Dockerfile.rhel7
@@ -60,6 +60,7 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.co
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
     mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
+    mkdir -p /usr/share/container-scripts/nginx/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx110 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.10/Dockerfile.rhel7
+++ b/1.10/Dockerfile.rhel7
@@ -29,8 +29,10 @@ LABEL summary="$SUMMARY" \
       version="1.10" \
       release="1.2"
 
-ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d
-ENV NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d
+ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=/opt/app-root/
 
 # We need to call 2 (!) yum commands before being able to enable repositories properly
 # This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
@@ -57,6 +59,7 @@ COPY ./root/ /
 RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.conf && \
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
+    mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx110 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.10/README.md
+++ b/1.10/README.md
@@ -51,6 +51,7 @@ S2I build folder structure:
 | :-------------------------- | ----------------------------------------- |
 |  ./nginx-cfg/*.conf         | Should contain all nginx configuration we want to include into image |
 |  ./nginx-default-cfg/*.conf | Contains any nginx config snippets to include in the default server block |
+|  ./nginx-pre-init/*.sh | Contains shell scripts that are sourced right before nginx is launched |
 |  ./                         | Should contain nginx application source code                         |
 
 Environment variables and volumes

--- a/1.10/root/usr/share/container-scripts/nginx/common.sh
+++ b/1.10/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/1.10/s2i/bin/assemble
+++ b/1.10/s2i/bin/assemble
@@ -31,7 +31,5 @@ if [ -d ./nginx-pre-init ]; then
   fi
 fi
 
-mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/
-
 # Fix source directory permissions
 fix-permissions ./

--- a/1.10/s2i/bin/assemble
+++ b/1.10/s2i/bin/assemble
@@ -11,6 +11,7 @@ if [ -d ./nginx-cfg ]; then
     cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
+  chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
 fi
 
 if [ -d ./nginx-default-cfg ]; then
@@ -19,7 +20,18 @@ if [ -d ./nginx-default-cfg ]; then
     cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
     rm -rf ./nginx-default-cfg
   fi
+  chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
 fi
+
+if [ -d ./nginx-pre-init ]; then
+  echo "---> Copying nginx pre-init scripts..."
+  if [ "$(ls -A ./nginx-pre-init/*)" ]; then
+    cp -v ./nginx-pre-init/* "${NGINX_APP_ROOT}/etc/nginx-pre-init"
+    rm -rf ./nginx-pre-init
+  fi
+fi
+
+mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.10/s2i/bin/run
+++ b/1.10/s2i/bin/run
@@ -4,4 +4,10 @@ source /opt/app-root/etc/generate_container_user
 
 set -e
 
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+if [ "$(ls -A ${NGINX_APP_ROOT}/etc/nginx-pre-init)" ]; then
+	process_extending_files ${NGINX_APP_ROOT}/etc/nginx-pre-init ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init
+fi
+
 exec nginx -g "daemon off;"

--- a/1.10/test/pre-init-test-app/index.html
+++ b/1.10/test/pre-init-test-app/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX is working</h1>
+</body>
+</html>

--- a/1.10/test/pre-init-test-app/index2.html
+++ b/1.10/test/pre-init-test-app/index2.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX2 is working</h1>
+</body>
+</html>

--- a/1.10/test/pre-init-test-app/nginx-cfg/default.conf
+++ b/1.10/test/pre-init-test-app/nginx-cfg/default.conf
@@ -1,0 +1,8 @@
+server {
+	listen       8080;
+	server_name  localhost2;
+	root         /opt/app-root/src;
+	index        ${INDEX_FILE};
+	resolver ${DNS_SERVER};
+
+}

--- a/1.10/test/pre-init-test-app/nginx-pre-init/init.sh
+++ b/1.10/test/pre-init-test-app/nginx-pre-init/init.sh
@@ -1,0 +1,19 @@
+setup_dns_env_var() {
+	if [ -z "$DNS_SERVER" ]; then
+	    export DNS_SERVER=`cat /etc/resolv.conf | grep "nameserver " | awk '{print $2}' | tr '\n' ' '`
+	    echo "Using system dns server ${DNS_SERVER}"
+	else
+	    echo "Using user defined dns server: ${DNS_SERVER}"
+	fi  
+}
+
+inject_env_vars() {
+	## Replace only specified environment variables in specified file.
+	envsubst '${DNS_SERVER},${INDEX_FILE}' < ${NGINX_CONFIGURATION_PATH}/$1 > output.conf
+	cp output.conf ${NGINX_CONFIGURATION_PATH}/$1
+	echo "This is $1: " && cat ${NGINX_CONFIGURATION_PATH}/$1
+}
+
+export INDEX_FILE=index2.html
+setup_dns_env_var
+inject_env_vars "default.conf"

--- a/1.10/test/run
+++ b/1.10/test/run
@@ -32,7 +32,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  s2i build ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build ${s2i_args} file://${test_dir}/${1} ${IMAGE_NAME} ${IMAGE_NAME}-${1}
 }
 
 prepare() {
@@ -43,7 +43,7 @@ prepare() {
   # TODO: S2I build require the application is a valid 'GIT' repository, we
   # should remove this restriction in the future when a file:// is used.
   info "Build the test application image"
-  pushd ${test_dir}/test-app >/dev/null
+  pushd ${test_dir}/${1} >/dev/null
   git init
   git config user.email "build@localhost" && git config user.name "builder"
   git add -A && git commit -m "Sample commit"
@@ -52,7 +52,7 @@ prepare() {
 
 run_test_application() {
   run_args=${CONTAINER_ARGS:-}
-  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-${1}
 }
 
 cleanup_test_app() {
@@ -68,17 +68,17 @@ cleanup_test_app() {
 
 cleanup() {
   info "Cleaning up the test application image"
-  if image_exists ${IMAGE_NAME}-testapp; then
-    docker rmi -f ${IMAGE_NAME}-testapp
+  if image_exists ${IMAGE_NAME}-${1}; then
+    docker rmi -f ${IMAGE_NAME}-${1}
   fi
-  rm -rf ${test_dir}/test-app/.git
+  rm -rf ${test_dir}/${1}/.git
 }
 
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
     info "TEST FAILED (${result})"
-    cleanup
+    cleanup $2
     exit $result
   fi
 }
@@ -116,6 +116,18 @@ test_scl_usage() {
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  test_command "$run_cmd" "$expected"
+  return $?
+}
+
+test_command() {
+  local run_cmd="$1"
+  local expected="$2"
+  local message="$3"
+
+  if [ $message ]; then
+    info ${3}
+  fi
   out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -125,7 +137,9 @@ test_scl_usage() {
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
-  fi
+  fi  
+
+  return 0
 }
 
 test_for_output()
@@ -174,19 +188,48 @@ test_connection() {
   return 1
 }
 
+test_connection_s2i() {
+  cat $cid_file
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+
+  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+     return 0
+  fi
+
+  return 1
+}
+
 test_application() {
   # Verify that the HTTP connection can be established to test application container
-  run_test_application &
+  run_test_application "test-app" &
 
   # Wait for the container to write it's CID file
   wait_for_cid
 
   test_scl_usage "nginx -v" "nginx version: nginx/1.10."
-  check_result $?
+  check_result $? "test-app"
 
   test_connection
-  check_result $?
+  check_result $? "test-app"
   cleanup_test_app
+}
+
+test_pre_init_script() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application "pre-init-test-app" &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_command "cat /opt/app-root/etc/nginx.d/default.conf | grep 'resolver' | sed -e 's/resolver\(.*\);/\1/' | grep 'DNS_SERVER'" ""
+  check_result $? "pre-init-test-app"
+
+  test_connection_s2i
+  check_result $? "pre-init-test-app"
+  cleanup_test_app
+
 }
 
 cid_file=$(mktemp -u --suffix=.cid)
@@ -195,23 +238,33 @@ cid_file=$(mktemp -u --suffix=.cid)
 # it from Docker hub
 s2i_args="--force-pull=false"
 
-prepare
-run_s2i_build
-check_result $?
+prepare "test-app"
+run_s2i_build "test-app"
+check_result $? "test-app"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage
-check_result $?
+check_result $? "test-app"
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage
-check_result $?
+check_result $? "test-app"
 
 # Test application with default uid
-test_application
+test_application 
 
 # Test application with random uid
 CONTAINER_ARGS="-u 12345" test_application
-cleanup
+cleanup "test-app"
+
+# Test pre-init script functionality
+cid_file=$(mktemp -u --suffix=.cid)
+
+prepare "pre-init-test-app"
+run_s2i_build "pre-init-test-app"
+check_result $? "pre-init-test-app"
+
+test_pre_init_script
+cleanup "pre-init-test-app"
 
 info "All tests finished successfully."

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -28,8 +28,10 @@ LABEL summary="$SUMMARY" \
       name="centos/nginx-112-centos7" \
       version="1"
 
-ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d
-ENV NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d
+ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=/opt/app-root/
 
 RUN yum install -y yum-utils gettext hostname && \
     yum install -y centos-release-scl-rh epel-release && \
@@ -51,6 +53,7 @@ COPY ./root/ /
 RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx112/nginx/nginx.conf && \
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
+    mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx112 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -54,6 +54,7 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx112/nginx/nginx.co
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
     mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
+    mkdir -p /usr/share/container-scripts/nginx/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx112 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.12/Dockerfile.rhel7
+++ b/1.12/Dockerfile.rhel7
@@ -28,8 +28,10 @@ LABEL summary="$SUMMARY" \
       name="rhscl/nginx-112-rhel7" \
       version="1"
 
-ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d
-ENV NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d
+ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=/opt/app-root/
 
 # We need to call 2 (!) yum commands before being able to enable repositories properly
 # This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
@@ -57,6 +59,7 @@ COPY ./root/ /
 RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx112/nginx/nginx.conf && \
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
+    mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx112 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.12/Dockerfile.rhel7
+++ b/1.12/Dockerfile.rhel7
@@ -60,6 +60,7 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx112/nginx/nginx.co
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
     mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
+    mkdir -p /usr/share/container-scripts/nginx/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx112 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.12/README.md
+++ b/1.12/README.md
@@ -51,6 +51,7 @@ S2I build folder structure:
 | :-------------------------- | ----------------------------------------- |
 |  ./nginx-cfg/*.conf         | Should contain all nginx configuration we want to include into image |
 |  ./nginx-default-cfg/*.conf | Contains any nginx config snippets to include in the default server block |
+|  ./nginx-pre-init/*.sh | Contains shell scripts that are sourced right before nginx is launched |
 |  ./                         | Should contain nginx application source code                         |
 
 Environment variables and volumes

--- a/1.12/root/usr/share/container-scripts/nginx/common.sh
+++ b/1.12/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/1.12/s2i/bin/assemble
+++ b/1.12/s2i/bin/assemble
@@ -31,7 +31,5 @@ if [ -d ./nginx-pre-init ]; then
   fi
 fi
 
-mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/
-
 # Fix source directory permissions
 fix-permissions ./

--- a/1.12/s2i/bin/assemble
+++ b/1.12/s2i/bin/assemble
@@ -11,6 +11,7 @@ if [ -d ./nginx-cfg ]; then
     cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
+  chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
 fi
 
 if [ -d ./nginx-default-cfg ]; then
@@ -19,7 +20,18 @@ if [ -d ./nginx-default-cfg ]; then
     cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
     rm -rf ./nginx-default-cfg
   fi
+  chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
 fi
+
+if [ -d ./nginx-pre-init ]; then
+  echo "---> Copying nginx pre-init scripts..."
+  if [ "$(ls -A ./nginx-pre-init/*)" ]; then
+    cp -v ./nginx-pre-init/* "${NGINX_APP_ROOT}/etc/nginx-pre-init"
+    rm -rf ./nginx-pre-init
+  fi
+fi
+
+mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.12/s2i/bin/run
+++ b/1.12/s2i/bin/run
@@ -4,4 +4,10 @@ source /opt/app-root/etc/generate_container_user
 
 set -e
 
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+if [ "$(ls -A ${NGINX_APP_ROOT}/etc/nginx-pre-init)" ]; then
+	process_extending_files ${NGINX_APP_ROOT}/etc/nginx-pre-init ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init
+fi
+
 exec nginx -g "daemon off;"

--- a/1.12/test/pre-init-test-app/index.html
+++ b/1.12/test/pre-init-test-app/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX is working</h1>
+</body>
+</html>

--- a/1.12/test/pre-init-test-app/index2.html
+++ b/1.12/test/pre-init-test-app/index2.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX2 is working</h1>
+</body>
+</html>

--- a/1.12/test/pre-init-test-app/nginx-cfg/default.conf
+++ b/1.12/test/pre-init-test-app/nginx-cfg/default.conf
@@ -1,0 +1,8 @@
+server {
+	listen       8080;
+	server_name  localhost2;
+	root         /opt/app-root/src;
+	index        ${INDEX_FILE};
+	resolver ${DNS_SERVER};
+
+}

--- a/1.12/test/pre-init-test-app/nginx-pre-init/init.sh
+++ b/1.12/test/pre-init-test-app/nginx-pre-init/init.sh
@@ -1,0 +1,19 @@
+setup_dns_env_var() {
+	if [ -z "$DNS_SERVER" ]; then
+	    export DNS_SERVER=`cat /etc/resolv.conf | grep "nameserver " | awk '{print $2}' | tr '\n' ' '`
+	    echo "Using system dns server ${DNS_SERVER}"
+	else
+	    echo "Using user defined dns server: ${DNS_SERVER}"
+	fi  
+}
+
+inject_env_vars() {
+	## Replace only specified environment variables in specified file.
+	envsubst '${DNS_SERVER},${INDEX_FILE}' < ${NGINX_CONFIGURATION_PATH}/$1 > output.conf
+	cp output.conf ${NGINX_CONFIGURATION_PATH}/$1
+	echo "This is $1: " && cat ${NGINX_CONFIGURATION_PATH}/$1
+}
+
+export INDEX_FILE=index2.html
+setup_dns_env_var
+inject_env_vars "default.conf"

--- a/1.12/test/run
+++ b/1.12/test/run
@@ -32,7 +32,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  s2i build ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build ${s2i_args} file://${test_dir}/${1} ${IMAGE_NAME} ${IMAGE_NAME}-${1}
 }
 
 prepare() {
@@ -43,7 +43,7 @@ prepare() {
   # TODO: S2I build require the application is a valid 'GIT' repository, we
   # should remove this restriction in the future when a file:// is used.
   info "Build the test application image"
-  pushd ${test_dir}/test-app >/dev/null
+  pushd ${test_dir}/${1} >/dev/null
   git init
   git config user.email "build@localhost" && git config user.name "builder"
   git add -A && git commit -m "Sample commit"
@@ -52,7 +52,7 @@ prepare() {
 
 run_test_application() {
   run_args=${CONTAINER_ARGS:-}
-  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-${1}
 }
 
 cleanup_test_app() {
@@ -68,17 +68,17 @@ cleanup_test_app() {
 
 cleanup() {
   info "Cleaning up the test application image"
-  if image_exists ${IMAGE_NAME}-testapp; then
-    docker rmi -f ${IMAGE_NAME}-testapp
+  if image_exists ${IMAGE_NAME}-${1}; then
+    docker rmi -f ${IMAGE_NAME}-${1}
   fi
-  rm -rf ${test_dir}/test-app/.git
+  rm -rf ${test_dir}/${1}/.git
 }
 
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
     info "TEST FAILED (${result})"
-    cleanup
+    cleanup $2
     exit $result
   fi
 }
@@ -116,6 +116,18 @@ test_scl_usage() {
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  test_command "$run_cmd" "$expected"
+  return $?
+}
+
+test_command() {
+  local run_cmd="$1"
+  local expected="$2"
+  local message="$3"
+
+  if [ $message ]; then
+    info ${3}
+  fi
   out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -125,7 +137,9 @@ test_scl_usage() {
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
-  fi
+  fi  
+
+  return 0
 }
 
 test_for_output()
@@ -174,19 +188,48 @@ test_connection() {
   return 1
 }
 
+test_connection_s2i() {
+  cat $cid_file
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+
+  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+     return 0
+  fi
+
+  return 1
+}
+
 test_application() {
   # Verify that the HTTP connection can be established to test application container
-  run_test_application &
+  run_test_application "test-app" &
 
   # Wait for the container to write it's CID file
   wait_for_cid
 
   test_scl_usage "nginx -v" "nginx version: nginx/1.12."
-  check_result $?
+  check_result $? "test-app"
 
   test_connection
-  check_result $?
+  check_result $? "test-app"
   cleanup_test_app
+}
+
+test_pre_init_script() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application "pre-init-test-app" &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_command "cat /opt/app-root/etc/nginx.d/default.conf | grep 'resolver' | sed -e 's/resolver\(.*\);/\1/' | grep 'DNS_SERVER'" ""
+  check_result $? "pre-init-test-app"
+
+  test_connection_s2i
+  check_result $? "pre-init-test-app"
+  cleanup_test_app
+
 }
 
 cid_file=$(mktemp -u --suffix=.cid)
@@ -195,23 +238,33 @@ cid_file=$(mktemp -u --suffix=.cid)
 # it from Docker hub
 s2i_args="--force-pull=false"
 
-prepare
-run_s2i_build
-check_result $?
+prepare "test-app"
+run_s2i_build "test-app"
+check_result $? "test-app"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage
-check_result $?
+check_result $? "test-app"
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage
-check_result $?
+check_result $? "test-app"
 
 # Test application with default uid
-test_application
+test_application 
 
 # Test application with random uid
 CONTAINER_ARGS="-u 12345" test_application
-cleanup
+cleanup "test-app"
+
+# Test pre-init script functionality
+cid_file=$(mktemp -u --suffix=.cid)
+
+prepare "pre-init-test-app"
+run_s2i_build "pre-init-test-app"
+check_result $? "pre-init-test-app"
+
+test_pre_init_script
+cleanup "pre-init-test-app"
 
 info "All tests finished successfully."

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -29,7 +29,10 @@ LABEL summary="$SUMMARY" \
       version="1.8" \
       release="1"
 
-ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d
+ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=/opt/app-root/
 
 RUN yum install -y yum-utils gettext hostname && \
     yum install -y centos-release-scl-rh epel-release && \
@@ -50,6 +53,8 @@ COPY ./root/ /
 # random UID.
 RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.conf && \
     mkdir -p /opt/app-root/etc/nginx.d/ && \
+    mkdir -p /opt/app-root/etc/nginx.default.d/ && \
+    mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx18 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -55,6 +55,7 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.con
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
     mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx18 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.8/Dockerfile.rhel7
+++ b/1.8/Dockerfile.rhel7
@@ -60,6 +60,7 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.con
     mkdir -p /opt/app-root/etc/nginx.d/ && \
     mkdir -p /opt/app-root/etc/nginx.default.d/ && \
     mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx18 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.8/Dockerfile.rhel7
+++ b/1.8/Dockerfile.rhel7
@@ -29,7 +29,10 @@ LABEL summary="$SUMMARY" \
       version="1.8" \
       release="13.1"
 
-ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d
+ENV NGINX_CONFIGURATION_PATH=/opt/app-root/etc/nginx.d \
+    NGINX_DEFAULT_CONF_PATH=/opt/app-root/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=/opt/app-root/
 
 # We need to call 2 (!) yum commands before being able to enable repositories properly
 # This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
@@ -55,6 +58,8 @@ COPY ./root/ /
 # random UID.
 RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.conf && \
     mkdir -p /opt/app-root/etc/nginx.d/ && \
+    mkdir -p /opt/app-root/etc/nginx.default.d/ && \
+    mkdir -p /opt/app-root/etc/nginx-pre-init/ && \
     chmod -R a+rwx /opt/app-root/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx18 && \
     chown -R 1001:0 /opt/app-root && \

--- a/1.8/README.md
+++ b/1.8/README.md
@@ -49,10 +49,12 @@ S2I build support
 Nginx server image can be extended using S2I tool (see Usage section).
 S2I build folder structure:
 
-|    Folder name         |    Description                            |
-| :--------------------- | ----------------------------------------- |
-|  ./nginx-cfg/*.conf    | Should contain all nginx configuration we want to include into image |
-|  ./                    | Should contain nginx application source code                         |
+|    Folder name              |    Description                            |
+| :-------------------------- | ----------------------------------------- |
+|  ./nginx-cfg/*.conf         | Should contain all nginx configuration we want to include into image |
+|  ./nginx-default-cfg/*.conf | Contains any nginx config snippets to include in the default server block |
+|  ./nginx-pre-init/*.sh | Contains shell scripts that are sourced right before nginx is launched |
+|  ./                         | Should contain nginx application source code                         |
 
 Environment variables and volumes
 -------------

--- a/1.8/root/opt/app-root/nginxconf.sed
+++ b/1.8/root/opt/app-root/nginxconf.sed
@@ -1,6 +1,7 @@
-s/^        listen       80/        listen       8080/
-s/^user  nginx;//
+/listen/s%80%8080%
+s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx18/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/opt/rh/rh-nginx18/root/usr/share/nginx/html%/opt/app-root/src%
 s%/var/opt/rh/rh-nginx18/log/nginx/error.log%stderr%
 s%access_log  /var/opt/rh/rh-nginx18/log/nginx/access.log  main;%%
+/#charset koi8-r;/a \\tinclude /opt/app-root/etc/nginx.default.d/*.conf;

--- a/1.8/root/usr/share/container-scripts/nginx/common.sh
+++ b/1.8/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/1.8/s2i/bin/assemble
+++ b/1.8/s2i/bin/assemble
@@ -31,7 +31,5 @@ if [ -d ./nginx-pre-init ]; then
   fi
 fi
 
-mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/
-
 # Fix source directory permissions
 fix-permissions ./

--- a/1.8/s2i/bin/assemble
+++ b/1.8/s2i/bin/assemble
@@ -11,7 +11,27 @@ if [ -d ./nginx-cfg ]; then
     cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
+  chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
 fi
+
+if [ -d ./nginx-default-cfg ]; then
+  echo "---> Copying nginx default server configuration files..."
+  if [ "$(ls -A ./nginx-default-cfg/*.conf)" ]; then
+    cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+    rm -rf ./nginx-default-cfg
+  fi
+  chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
+fi
+
+if [ -d ./nginx-pre-init ]; then
+  echo "---> Copying nginx pre-init scripts..."
+  if [ "$(ls -A ./nginx-pre-init/*)" ]; then
+    cp -v ./nginx-pre-init/* "${NGINX_APP_ROOT}/etc/nginx-pre-init"
+    rm -rf ./nginx-pre-init
+  fi
+fi
+
+mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init/
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.8/s2i/bin/run
+++ b/1.8/s2i/bin/run
@@ -4,4 +4,10 @@ source /opt/app-root/etc/generate_container_user
 
 set -e
 
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+if [ "$(ls -A ${NGINX_APP_ROOT}/etc/nginx-pre-init)" ]; then
+	process_extending_files ${NGINX_APP_ROOT}/etc/nginx-pre-init ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-pre-init
+fi
+
 exec nginx -g "daemon off;"

--- a/1.8/test/pre-init-test-app/index.html
+++ b/1.8/test/pre-init-test-app/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX is working</h1>
+</body>
+</html>

--- a/1.8/test/pre-init-test-app/index2.html
+++ b/1.8/test/pre-init-test-app/index2.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX2 is working</h1>
+</body>
+</html>

--- a/1.8/test/pre-init-test-app/nginx-cfg/default.conf
+++ b/1.8/test/pre-init-test-app/nginx-cfg/default.conf
@@ -1,0 +1,8 @@
+server {
+	listen       8080;
+	server_name  localhost2;
+	root         /opt/app-root/src;
+	index        ${INDEX_FILE};
+	resolver ${DNS_SERVER};
+
+}

--- a/1.8/test/pre-init-test-app/nginx-pre-init/init.sh
+++ b/1.8/test/pre-init-test-app/nginx-pre-init/init.sh
@@ -1,0 +1,19 @@
+setup_dns_env_var() {
+	if [ -z "$DNS_SERVER" ]; then
+	    export DNS_SERVER=`cat /etc/resolv.conf | grep "nameserver " | awk '{print $2}' | tr '\n' ' '`
+	    echo "Using system dns server ${DNS_SERVER}"
+	else
+	    echo "Using user defined dns server: ${DNS_SERVER}"
+	fi  
+}
+
+inject_env_vars() {
+	## Replace only specified environment variables in specified file.
+	envsubst '${DNS_SERVER},${INDEX_FILE}' < ${NGINX_CONFIGURATION_PATH}/$1 > output.conf
+	cp output.conf ${NGINX_CONFIGURATION_PATH}/$1
+	echo "This is $1: " && cat ${NGINX_CONFIGURATION_PATH}/$1
+}
+
+export INDEX_FILE=index2.html
+setup_dns_env_var
+inject_env_vars "default.conf"

--- a/1.8/test/run
+++ b/1.8/test/run
@@ -32,7 +32,7 @@ container_ip() {
 }
 
 run_s2i_build() {
-  s2i build ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build ${s2i_args} file://${test_dir}/${1} ${IMAGE_NAME} ${IMAGE_NAME}-${1}
 }
 
 prepare() {
@@ -43,7 +43,7 @@ prepare() {
   # TODO: S2I build require the application is a valid 'GIT' repository, we
   # should remove this restriction in the future when a file:// is used.
   info "Build the test application image"
-  pushd ${test_dir}/test-app >/dev/null
+  pushd ${test_dir}/${1} >/dev/null
   git init
   git config user.email "build@localhost" && git config user.name "builder"
   git add -A && git commit -m "Sample commit"
@@ -52,7 +52,7 @@ prepare() {
 
 run_test_application() {
   run_args=${CONTAINER_ARGS:-}
-  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-testapp
+  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-${1}
 }
 
 cleanup_test_app() {
@@ -68,17 +68,17 @@ cleanup_test_app() {
 
 cleanup() {
   info "Cleaning up the test application image"
-  if image_exists ${IMAGE_NAME}-testapp; then
-    docker rmi -f ${IMAGE_NAME}-testapp
+  if image_exists ${IMAGE_NAME}-${1}; then
+    docker rmi -f ${IMAGE_NAME}-${1}
   fi
-  rm -rf ${test_dir}/test-app/.git
+  rm -rf ${test_dir}/${1}/.git
 }
 
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
     info "TEST FAILED (${result})"
-    cleanup
+    cleanup $2
     exit $result
   fi
 }
@@ -116,6 +116,18 @@ test_scl_usage() {
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  test_command "$run_cmd" "$expected"
+  return $?
+}
+
+test_command() {
+  local run_cmd="$1"
+  local expected="$2"
+  local message="$3"
+
+  if [ $message ]; then
+    info ${3}
+  fi
   out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -125,55 +137,30 @@ test_scl_usage() {
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
-  fi
+  fi  
+
+  return 0
 }
 
-test_connection() {
-  cat $cid_file
-  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
-  local max_attempts=10
+test_for_output()
+{
+  local url="$1"
+  local expect="$2"
+  local host="${3-localhost}"
+  local max_attempts=5
   local sleep_time=1
   local attempt=1
   local result=1
 
-  while [ $attempt -le $max_attempts ]; do
-    response=$(curl -s -H "Host:localhost" http://$(container_ip):${test_port}/)
-    echo "${response}"
-    status=$?
-    if [ $status -eq 0 ]; then
-      if echo "${response}" | grep -q "NGINX is working"; then
-        result=0
-        break
-      else
-        echo "Response: ${response}"
-      fi
-    fi
-    attempt=$(( $attempt + 1 ))
-    sleep $sleep_time
-  done
+  info "Testing URL $url with HTTP hostname ${host} produces output $expect"
 
   while [ $attempt -le $max_attempts ]; do
-    response=$(curl -s -H "Host:localhost2" http://$(container_ip):${test_port}/)
+    response=$(curl -s -H "Host: ${host}" ${url})
     echo "${response}"
     status=$?
     if [ $status -eq 0 ]; then
-      if echo "${response}" | grep -q "NGINX2 is working"; then
-        result=0
-        break
-      else
-        echo "Response: ${response}"
-      fi
-    fi
-    attempt=$(( $attempt + 1 ))
-    sleep $sleep_time
-  done
-
-  while [ $attempt -le $max_attempts ]; do
-    response=$(curl -s -H "Host:localhost" http://$(container_ip):${test_port}/nginx-cfg/default.conf)
-    echo "${response}"
-    status=$?
-    if [ $status -eq 0 ]; then
-      if echo "${response}" | grep -q "404"; then
+      if echo "${response}" | grep -q "${expect}"; then
+        info "Success!"
         result=0
         break
       else
@@ -187,19 +174,62 @@ test_connection() {
   return $result
 }
 
+test_connection() {
+  cat $cid_file
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+
+  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):${test_port}/aliased/index2.html" "NGINX2 is working"  &&
+     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+     return 0
+  fi
+
+  return 1
+}
+
+test_connection_s2i() {
+  cat $cid_file
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+
+  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+     return 0
+  fi
+
+  return 1
+}
+
 test_application() {
   # Verify that the HTTP connection can be established to test application container
-  run_test_application &
+  run_test_application "test-app" &
 
   # Wait for the container to write it's CID file
   wait_for_cid
 
   test_scl_usage "nginx -v" "nginx version: nginx/1.8."
-  check_result $?
+  check_result $? "test-app"
 
   test_connection
-  check_result $?
+  check_result $? "test-app"
   cleanup_test_app
+}
+
+test_pre_init_script() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application "pre-init-test-app" &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_command "cat /opt/app-root/etc/nginx.d/default.conf | grep 'resolver' | sed -e 's/resolver\(.*\);/\1/' | grep 'DNS_SERVER'" ""
+  check_result $? "pre-init-test-app"
+
+  test_connection_s2i
+  check_result $? "pre-init-test-app"
+  cleanup_test_app
+
 }
 
 cid_file=$(mktemp -u --suffix=.cid)
@@ -208,23 +238,33 @@ cid_file=$(mktemp -u --suffix=.cid)
 # it from Docker hub
 s2i_args="--force-pull=false"
 
-prepare
-run_s2i_build
-check_result $?
+prepare "test-app"
+run_s2i_build "test-app"
+check_result $? "test-app"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage
-check_result $?
+check_result $? "test-app"
 
 # Verify the 'usage' script is working properly when running the base image with 'docker run ...'
 test_docker_run_usage
-check_result $?
+check_result $? "test-app"
 
 # Test application with default uid
-test_application
+test_application 
 
 # Test application with random uid
 CONTAINER_ARGS="-u 12345" test_application
-cleanup
+cleanup "test-app"
+
+# Test pre-init script functionality
+cid_file=$(mktemp -u --suffix=.cid)
+
+prepare "pre-init-test-app"
+run_s2i_build "pre-init-test-app"
+check_result $? "pre-init-test-app"
+
+test_pre_init_script
+cleanup "pre-init-test-app"
 
 info "All tests finished successfully."

--- a/1.8/test/test-app/nginx-default-cfg/alias.conf
+++ b/1.8/test/test-app/nginx-default-cfg/alias.conf
@@ -1,0 +1,3 @@
+location /aliased/ {
+         alias /opt/app-root/src/;
+}


### PR DESCRIPTION
Hi,

This PR would add ability to execute user supplied scripts just before nginx start. This would fix #18, because it implements #19, and it would also fix #20.

All user has to do is place `.sh` scripts in `./nginx-pre-init/` folder, and these scripts will then be sourced right before nginx starts.

I have also modified permissions on config files, for when container is not running on user 1001 (as seen in tests)

This PR also includes test case for each version and modified test running script to be able to run more than one test. 

I've separated changes into three commits for each version to track changes more transparently. Added functionality is the same in all of them, except for 1.8, where I decided to add option to extend the default server block, which I took from 1.10 & 1.12. 