### PR TITLE
Do not use VOLUMES because it fails in OpenShift Online

### DIFF
--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -60,8 +60,10 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.co
 
 USER 1001
 
-VOLUME ["/opt/rh/rh-nginx110/root/usr/share/nginx/html"]
-VOLUME ["/var/opt/rh/rh-nginx110/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx110/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx110/log/nginx/"]
 
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \

--- a/1.10/Dockerfile.rhel7
+++ b/1.10/Dockerfile.rhel7
@@ -62,8 +62,10 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.co
 
 USER 1001
 
-VOLUME ["/opt/rh/rh-nginx110/root/usr/share/nginx/html"]
-VOLUME ["/var/opt/rh/rh-nginx110/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx110/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx110/log/nginx/"]
 
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -59,8 +59,10 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx112/nginx/nginx.co
 
 USER 1001
 
-VOLUME ["/opt/rh/rh-nginx112/root/usr/share/nginx/html"]
-VOLUME ["/var/opt/rh/rh-nginx112/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx112/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx112/log/nginx/"]
 
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \

--- a/1.12/Dockerfile.fedora
+++ b/1.12/Dockerfile.fedora
@@ -63,7 +63,9 @@ RUN sed -i -f /opt/app-root/nginxconf-fed.sed /etc/nginx/nginx.conf && \
 
 USER 1001
 
-VOLUME ["/usr/share/nginx/html"]
-VOLUME ["/var/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/usr/share/nginx/html"]
+# VOLUME ["/var/log/nginx/"]
 
 CMD $STI_SCRIPTS_PATH/usage

--- a/1.12/Dockerfile.rhel7
+++ b/1.12/Dockerfile.rhel7
@@ -61,8 +61,10 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx112/nginx/nginx.co
 
 USER 1001
 
-VOLUME ["/opt/rh/rh-nginx112/root/usr/share/nginx/html"]
-VOLUME ["/var/opt/rh/rh-nginx112/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx112/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx112/log/nginx/"]
 
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -58,8 +58,10 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.con
 
 USER 1001
 
-VOLUME ["/opt/rh/rh-nginx18/root/usr/share/nginx/html"]
-VOLUME ["/var/opt/rh/rh-nginx18/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx18/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx18/log/nginx/"]
 
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \

--- a/1.8/Dockerfile.rhel7
+++ b/1.8/Dockerfile.rhel7
@@ -60,8 +60,10 @@ RUN sed -i -f /opt/app-root/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.con
 
 USER 1001
 
-VOLUME ["/opt/rh/rh-nginx18/root/usr/share/nginx/html"]
-VOLUME ["/var/opt/rh/rh-nginx18/log/nginx/"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-nginx18/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-nginx18/log/nginx/"]
 
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \
     ENV=/opt/app-root/etc/scl_enable \


### PR DESCRIPTION
It's rationalized in https://github.com/sclorg/httpd-container/issues/30

Ideally this should be reverted once OpenShift Online is fixed.