### PR TITLE
Fix stdout by follow upstream logging practices for nginx in docker

### DIFF
--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -55,16 +55,19 @@ COPY ./root/ /
 # In order to drop the root user, we have to make some directories world
 # writeable as OpenShift default security model is to run the container under
 # random UID.
-RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed /etc/opt/rh/rh-nginx110/nginx/nginx.conf && \
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed /etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf && \
     mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
     mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
     mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
     mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx && \
+    ln -sf /dev/stdout /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/error.log && \
     chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
-    chmod -R a+rwx /var/opt/rh/rh-nginx110 && \
+    chmod -R a+rwx /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
     chown -R 1001:0 ${NGINX_APP_ROOT} && \
-    chown -R 1001:0 /var/opt/rh/rh-nginx110 && \
+    chown -R 1001:0 /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
     rpm-file-permissions
 

--- a/1.10/root/opt/app-root/nginxconf.sed
+++ b/1.10/root/opt/app-root/nginxconf.sed
@@ -3,5 +3,3 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx110/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx110/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx110/root/usr/share/nginx/html%/opt/app-root/src%
-s%/var/opt/rh/rh-nginx110/log/nginx/error.log%stderr%
-s%access_log  /var/opt/rh/rh-nginx110/log/nginx/access.log  main;%%

--- a/1.12/Dockerfile
+++ b/1.12/Dockerfile
@@ -62,11 +62,14 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
     mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
     mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
     mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx && \
+    ln -sf /dev/stdout /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/error.log && \
     chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
-    chmod -R a+rwx /var/opt/rh/rh-nginx112 && \
+    chmod -R a+rwx /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
     chown -R 1001:0 ${NGINX_APP_ROOT} && \
-    chown -R 1001:0 /var/opt/rh/rh-nginx112 && \
+    chown -R 1001:0 /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
     rpm-file-permissions
 

--- a/1.12/root/opt/app-root/nginxconf.sed
+++ b/1.12/root/opt/app-root/nginxconf.sed
@@ -3,5 +3,3 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx112/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx112/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx112/root/usr/share/nginx/html%/opt/app-root/src%
-s%/var/opt/rh/rh-nginx112/log/nginx/error.log%stderr%
-s%access_log  /var/opt/rh/rh-nginx112/log/nginx/access.log  main;%%

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -55,16 +55,19 @@ COPY ./root/ /
 # In order to drop the root user, we have to make some directories world
 # writeable as OpenShift default security model is to run the container under
 # random UID.
-RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed /etc/opt/rh/rh-nginx18/nginx/nginx.conf && \
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed /etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf && \
     mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
     mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
     mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
     mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx && \
+    ln -sf /dev/stdout /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/error.log && \
     chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
-    chmod -R a+rwx /var/opt/rh/rh-nginx18 && \
+    chmod -R a+rwx /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
     chown -R 1001:0 ${NGINX_APP_ROOT} && \
-    chown -R 1001:0 /var/opt/rh/rh-nginx18 && \
+    chown -R 1001:0 /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
     rpm-file-permissions
 

--- a/1.8/root/opt/app-root/nginxconf.sed
+++ b/1.8/root/opt/app-root/nginxconf.sed
@@ -2,6 +2,4 @@
 s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx18/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/opt/rh/rh-nginx18/root/usr/share/nginx/html%/opt/app-root/src%
-s%/var/opt/rh/rh-nginx18/log/nginx/error.log%stderr%
-s%access_log  /var/opt/rh/rh-nginx18/log/nginx/access.log  main;%%
 /#charset koi8-r;/a \\tinclude /opt/app-root/etc/nginx.default.d/*.conf;


### PR DESCRIPTION
Per upstream nginx images, just symlink the default log files to the stdout/err devices and dont bother trying to reconfigure the nginx.conf file

https://stackoverflow.com/questions/22541333/have-nginx-access-log-and-error-log-log-to-stdout-and-stderr-of-master-process/42369571#42369571
https://github.com/nginxinc/docker-nginx/issues/87
https://github.com/nginxinc/docker-nginx/blob/master/mainline/alpine/Dockerfile#L136-L137

Closes #53 