### PR TITLE
Update common submodule and fix tests

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -33,5 +33,5 @@ ct_os_test_template_app ${IMAGE_NAME} \
                         https://raw.githubusercontent.com/sclorg/nginx-ex/${BRANCH_TO_TEST}/openshift/templates/nginx.json \
                         nginx \
                         'Welcome to your static nginx application on OpenShift' \
-                        8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NGINX_VERSION=${VERSION}"
+                        8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
 


### PR DESCRIPTION
It is necessary to define `NAME` variable, so we don't need to guess names of the services.