### PR TITLE
Remove error page configuration.

### DIFF
--- a/1.10/root/opt/app-root/nginxconf.sed
+++ b/1.10/root/opt/app-root/nginxconf.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx110/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx110/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx110/root/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.12/root/opt/app-root/nginxconf.sed
+++ b/1.12/root/opt/app-root/nginxconf.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx112/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx112/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx112/root/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.14/root/opt/app-root/nginxconf-fed.sed
+++ b/1.14/root/opt/app-root/nginxconf-fed.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.14/root/opt/app-root/nginxconf.sed
+++ b/1.14/root/opt/app-root/nginxconf.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx114/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx114/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx114/root/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.16/root/opt/app-root/nginxconf-fed.sed
+++ b/1.16/root/opt/app-root/nginxconf-fed.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.16/root/opt/app-root/nginxconf.sed
+++ b/1.16/root/opt/app-root/nginxconf.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx116/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx116/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx116/root/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.18/root/opt/app-root/nginxconf-fed.sed
+++ b/1.18/root/opt/app-root/nginxconf-fed.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d

--- a/1.18/root/opt/app-root/nginxconf.sed
+++ b/1.18/root/opt/app-root/nginxconf.sed
@@ -3,3 +3,8 @@ s/^user *nginx;//
 s%/etc/opt/rh/rh-nginx118/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
 s%/etc/opt/rh/rh-nginx118/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
 s%/opt/rh/rh-nginx118/root/usr/share/nginx/html%/opt/app-root/src%
+
+# See: https://github.com/sclorg/nginx-container/pull/69
+/error_page/d
+/40x.html/,+1d
+/50x.html/,+1d


### PR DESCRIPTION
This should be avoid error like

```
2018/11/05 16:36:55 [error] 28#0: *208 open() "/opt/app-root/src/50x.html" failed (2: No such file or directory), client: ::1, server: _, request: "GET /nonexist/api/v1/ping HTTP/1.1", upstream: "http://localhost:8081/nonexist/api/v1/ping ", host: "localhost:8080"
::1 - - [05/Nov/2018:16:36:55 +0100] "GET /nonexist/api/v1/ping HTTP/1.1" 404 162 "-" "curl/7.29.0" "-"
```

Normally this should be a 50x error but a 404 is return.

Adding try_files behavior to possible provide custom error pages inside `/opt/app-root/src/`