### PR TITLE
Add Nginx 1.14 container

### DIFF
--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -1,0 +1,87 @@
+FROM centos/s2i-core-centos7
+
+# RHSCL rh-nginx114 image.
+#
+# Volumes:
+#  * /var/opt/rh/rh-nginx114/log/nginx/ - Storage for logs
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV NAME=nginx \
+    NGINX_VERSION=1.14 \
+    NGINX_SHORT_VER=114 \
+    VERSION=0
+
+ENV SUMMARY="Platform for running nginx $NGINX_VERSION or building nginx-based application" \
+    DESCRIPTION="Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP \
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container \
+image provides a containerized packaging of the nginx $NGINX_VERSION daemon. The image can be used \
+as a base image for other applications based on nginx $NGINX_VERSION web server. \
+Nginx server image can be extended using source-to-image tool."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Nginx ${NGINX_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.expose-services="8443:https" \
+      io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
+      com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
+      name="centos/${NAME}-${NGINX_SHORT_VER}-centos7" \
+      version="${NGINX_VERSION}" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT}
+
+RUN yum install -y yum-utils gettext hostname && \
+    yum install -y centos-release-scl-rh && \
+    INSTALL_PKGS="nss_wrapper bind-utils rh-${NAME}${NGINX_SHORT_VER} rh-${NAME}${NGINX_SHORT_VER}-nginx" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    chmod a+rwx ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/log/nginx && \
+    ln -sf /dev/stdout /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/log/nginx/error.log && \
+    chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
+    chmod -R a+rwx /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER} && \
+    chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 ${NGINX_APP_ROOT} && \
+    chown -R 1001:0 /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER} && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/log/nginx/"]
+
+ENV BASH_ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${NGINX_APP_ROOT}/etc/scl_enable"
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/1.14/Dockerfile.fedora
+++ b/1.14/Dockerfile.fedora
@@ -1,0 +1,84 @@
+FROM registry.fedoraproject.org/f29/s2i-core:latest
+
+# nginx 1.14 image.
+#
+# Volumes:
+#  * /var/log/nginx/ - Storage for logs
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV NAME=nginx \
+    NGINX_VERSION=1.14 \
+    NGINX_SHORT_VER=114 \
+    VERSION=0 \
+    ARCH=x86_64
+
+ENV SUMMARY="Platform for running nginx $NGINX_VERSION or building nginx-based application" \
+    DESCRIPTION="Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP \
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container \
+image provides a containerized packaging of the nginx $NGINX_VERSION daemon. The image can be used \
+as a base image for other applications based on nginx $NGINX_VERSION web server. \
+Nginx server image can be extended using source-to-image tool."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Nginx ${NGINX_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.expose-services="8443:https" \
+      io.openshift.tags="builder,${NAME},${NAME}${NGINX_SHORT_VER}" \
+      com.redhat.component="${NAME}" \
+      name="${FGC}/${NAME}" \
+      version="${VERSION}" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> ${FGC}/nginx <APP-NAME>"
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT}
+
+RUN dnf install -y gettext hostname && \
+    INSTALL_PKGS="nss_wrapper bind-utils nginx" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    dnf clean all
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf-fed.sed ${NGINX_CONF_PATH} && \
+    chmod a+rwx ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p /var/log/nginx && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
+    chmod -R a+rwx /var /run && \
+    chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 ${NGINX_APP_ROOT} && \
+    chown -R 1001:0 /var && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    rpm-file-permissions
+
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/usr/share/nginx/html"]
+# VOLUME ["/var/log/nginx/"]
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/1.14/Dockerfile.fedora
+++ b/1.14/Dockerfile.fedora
@@ -42,7 +42,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_APP_ROOT=${APP_ROOT}
 
 RUN dnf install -y gettext hostname && \
-    INSTALL_PKGS="nss_wrapper bind-utils nginx" && \
+    INSTALL_PKGS="nss_wrapper bind-utils ${NAME}-${NGINX_VERSION}.*" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/1.14/Dockerfile.rhel7
+++ b/1.14/Dockerfile.rhel7
@@ -1,0 +1,84 @@
+FROM rhscl/s2i-core-rhel7:1
+
+# RHSCL rh-nginx114 image.
+#
+# Volumes:
+#  * /var/opt/rh/rh-nginx114/log/nginx/ - Storage for logs
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV NAME=nginx \
+    NGINX_VERSION=1.14 \
+    NGINX_SHORT_VER=114 \
+    VERSION=0
+
+ENV SUMMARY="Platform for running nginx $NGINX_VERSION or building nginx-based application" \
+    DESCRIPTION="Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP \
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container \
+image provides a containerized packaging of the nginx $NGINX_VERSION daemon. The image can be used \
+as a base image for other applications based on nginx $NGINX_VERSION web server. \
+Nginx server image can be extended using source-to-image tool."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Nginx ${NGINX_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.expose-services="8443:https" \
+      io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
+      com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
+      name="rhscl/${NAME}-${NGINX_SHORT_VER}-rhel7" \
+      version="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> rhscl/${NAME}-${NGINX_SHORT_VER}-rhel7:latest <APP-NAME>"
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT}
+
+RUN yum install -y yum-utils && \
+    prepare-yum-repositories rhel-server-rhscl-7-rpms && \
+    INSTALL_PKGS="nss_wrapper bind-utils gettext hostname rh-${NAME}${NGINX_SHORT_VER} rh-${NAME}${NGINX_SHORT_VER}-nginx" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# In order to drop the root user, we have to make some directories world
+# writeable as OpenShift default security model is to run the container under
+# random UID.
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    chmod a+rwx ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
+    chmod -R a+rwx /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER} && \
+    chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 ${NGINX_APP_ROOT} && \
+    chown -R 1001:0 /var/opt/rh/rh-${NAME}${NGINX_SHORT_VER} && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/root/usr/share/nginx/html"]
+# VOLUME ["/var/opt/rh/rh-${NAME}${NGINX_SHORT_VER}/log/nginx/"]
+
+ENV BASH_ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    ENV=${NGINX_APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${NGINX_APP_ROOT}/etc/scl_enable"
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/1.14/README.md
+++ b/1.14/README.md
@@ -36,6 +36,15 @@ resulting image with [Docker](http://docker.io) execute:
     $ docker run -p 8080:8080 nginx-sample-app
     ```
 
+*  **For Fedora based image**
+    ```
+    $ git clone https://github.com/sclorg/nginx-container.git
+    $ cd nginx-container/1.14
+    $ docker build -f Dockerfile.fedora -t nginx-114-fedora
+    $ s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.14/test/test-app/ nginx-114-fedora nginx-sample-app
+    $ docker run -p 8080:8080 nginx-sample-app
+    ```
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080

--- a/1.14/README.md
+++ b/1.14/README.md
@@ -1,0 +1,96 @@
+Nginx 1.14 server and a reverse proxy server container image
+=========================================================
+
+This container image includes Nginx 1.14 server and a reverse server for OpenShift and general usage.
+Users can choose RHEL based image.
+The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nginx-114-rhel7)
+as registry.access.redhat.com/rhscl/nginx-114-rhel7.
+
+
+Description
+-----------
+
+Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP 
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container 
+image provides a containerized packaging of the nginx 1.14 daemon. The image can be used 
+as a base image for other applications based on nginx 1.14 web server. 
+Nginx server image can be extended using source-to-image tool.
+
+
+Usage
+-----
+
+To build a simple [sample-app](https://github.com/sclorg/nginx-container/tree/master/1.14/test/test-app) application
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.14/test/test-app/ rhscl/nginx-114-rhel7 nginx-sample-app
+    $ docker run -p 8080:8080 nginx-sample-app
+    ```
+    
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.14/test/test-app/ centos/nginx-114-centos7 nginx-sample-app
+    $ docker run -p 8080:8080 nginx-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+
+S2I build support
+-------------
+Nginx server image can be extended using S2I tool (see Usage section).
+S2I build folder structure:
+
+**`./nginx.conf`**--
+       The main nginx configuration file
+
+**`./nginx-cfg/*.conf`**  
+       Should contain all nginx configuration we want to include into image
+
+**`./nginx-default-cfg/*.conf`**  
+       Contains any nginx config snippets to include in the default server block
+
+**`./nginx-start/*.sh`**  
+       Contains shell scripts that are sourced right before nginx is launched
+
+**`./`**  
+       Should contain nginx application source code
+
+
+Environment variables and volumes
+-------------
+The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the docker run command:
+
+
+**`NGINX_LOG_TO_VOLUME`**  
+       When `NGINX_LOG_TO_VOLUME` is set, nginx logs into `/var/opt/rh/rh-nginx114/log/nginx/`
+
+
+You can mount your own web root like this:
+```
+$ docker run -v <DIR>:/var/www/html/ <container>
+```
+You can replace \<DIR> with location of your web root. Please note that this has to be an **absolute** path, due to Docker requirements.
+
+
+Troubleshooting
+---------------
+By default, nginx logs into standard output, so the log is available in the container log. The log can be examined by running:
+
+    docker logs <container>
+
+**If `NGINX_LOG_TO_VOLUME` variable is set, nginx logs into `/var/opt/rh/rh-nginx114/log/nginx/`, which can be mounted to host system using the container volumes.**
+
+
+See also
+--------
+Dockerfile and other sources for this container image are available on
+https://github.com/sclorg/nginx-container.
+In that repository, Dockerfile for CentOS is called Dockerfile, Dockerfile
+for RHEL is called Dockerfile.rhel7.

--- a/1.14/README.md
+++ b/1.14/README.md
@@ -41,7 +41,7 @@ resulting image with [Docker](http://docker.io) execute:
     $ git clone https://github.com/sclorg/nginx-container.git
     $ cd nginx-container/1.14
     $ docker build -f Dockerfile.fedora -t nginx-114-fedora
-    $ s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.14/test/test-app/ nginx-114-fedora nginx-sample-app
+    $ s2i build https://github.com/sclorg/nginx-container.git -e OS=fedora --context-dir=1.14/test/test-app/ nginx-114-fedora nginx-sample-app
     $ docker run -p 8080:8080 nginx-sample-app
     ```
 

--- a/1.14/cccp.yml
+++ b/1.14/cccp.yml
@@ -1,0 +1,3 @@
+# This is for the purpose of building this container on
+# the centos container pipeline.
+job-id: nginx-114-centos7

--- a/1.14/content_sets.yml
+++ b/1.14/content_sets.yml
@@ -1,0 +1,10 @@
+# This is a file defining which content sets are needed to update content in 
+# this image. Data provided here helps determine which images are vulnerable to
+# specific CVEs. Generally you should only need to update this file when:
+#    1. You start depending on new product
+#    2. You are preparing new product release and your content sets will change
+---
+x86_64:
+- rhel-7-server-rpms
+- rhel-7-server-optional-rpms
+- rhel-server-rhscl-7-rpms

--- a/1.14/root/opt/app-root/etc/generate_container_user
+++ b/1.14/root/opt/app-root/etc/generate_container_user
@@ -1,0 +1,9 @@
+# Set current user in nss_wrapper
+PASSWD_DIR="/opt/app-root/etc"
+
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < ${PASSWD_DIR}/passwd.template > ${PASSWD_DIR}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${PASSWD_DIR}/passwd
+export NSS_WRAPPER_GROUP=/etc/group

--- a/1.14/root/opt/app-root/etc/passwd.template
+++ b/1.14/root/opt/app-root/etc/passwd.template
@@ -1,0 +1,15 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:99:99:Nobody:/:/sbin/nologin
+default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin
+apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin

--- a/1.14/root/opt/app-root/etc/scl_enable
+++ b/1.14/root/opt/app-root/etc/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-nginx114

--- a/1.14/root/opt/app-root/nginxconf-fed.sed
+++ b/1.14/root/opt/app-root/nginxconf-fed.sed
@@ -1,0 +1,7 @@
+/listen/s%80%8080%
+s/^user *nginx;//
+s%/etc/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
+s%/etc/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
+s%/usr/share/nginx/html%/opt/app-root/src%
+s%/var/log/nginx/error.log%stderr%
+s%access_log  /var/log/nginx/access.log  main;%%

--- a/1.14/root/opt/app-root/nginxconf.sed
+++ b/1.14/root/opt/app-root/nginxconf.sed
@@ -1,0 +1,5 @@
+/listen/s%80%8080%
+s/^user *nginx;//
+s%/etc/opt/rh/rh-nginx114/nginx/conf.d/%/opt/app-root/etc/nginx.d/%
+s%/etc/opt/rh/rh-nginx114/nginx/default.d/%/opt/app-root/etc/nginx.default.d/%
+s%/opt/rh/rh-nginx114/root/usr/share/nginx/html%/opt/app-root/src%

--- a/1.14/root/usr/share/container-scripts/nginx/common.sh
+++ b/1.14/root/usr/share/container-scripts/nginx/common.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    if [ $filename ]; then
+      echo "=> sourcing $filename ..."
+      # Custom file is prefered
+      if [ -f $custom_dir/$filename ]; then
+        source $custom_dir/$filename
+      elif [ -f $default_dir/$filename ]; then 
+        source $default_dir/$filename
+      fi
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}

--- a/1.14/s2i/bin/assemble
+++ b/1.14/s2i/bin/assemble
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+echo "---> Installing application source"
+cp -Rf /tmp/src/. ./
+
+if [ -f ./nginx.conf ]; then
+  echo "---> Copying nginx.conf configuration file..."
+  cp -v ./nginx.conf "${NGINX_CONF_PATH}"
+  rm -f ./nginx.conf
+fi
+
+if [ -d ./nginx-cfg ]; then
+  echo "---> Copying nginx configuration files..."
+  if [ "$(ls -A ./nginx-cfg/*.conf)" ]; then
+    cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+    rm -rf ./nginx-cfg
+  fi
+  chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
+fi
+
+if [ -d ./nginx-default-cfg ]; then
+  echo "---> Copying nginx default server configuration files..."
+  if [ "$(ls -A ./nginx-default-cfg/*.conf)" ]; then
+    cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+    rm -rf ./nginx-default-cfg
+  fi
+  chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
+fi
+
+if [ -d ./nginx-start ]; then
+  echo "---> Copying nginx start-hook scripts..."
+  if [ "$(ls -A ./nginx-start/* 2>/dev/null)" ]; then
+    cp -v ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
+    rm -rf ./nginx-start
+  fi
+fi
+
+# Fix source directory permissions
+fix-permissions ./

--- a/1.14/s2i/bin/assemble
+++ b/1.14/s2i/bin/assemble
@@ -5,7 +5,11 @@ set -e
 echo "---> Installing application source"
 cp -Rf /tmp/src/. ./
 
-if [ -f ./nginx.conf ]; then
+if [[ -n "${OS}"  &&  -f ./nginx.conf.${OS} ]]; then
+  echo "---> Copying nginx.conf.${OS} configuration file..."
+  cp -v ./nginx.conf.${OS} "${NGINX_CONF_PATH}"
+  rm -f ./nginx.conf.${OS}
+elif [ -f ./nginx.conf ]; then
   echo "---> Copying nginx.conf configuration file..."
   cp -v ./nginx.conf "${NGINX_CONF_PATH}"
   rm -f ./nginx.conf

--- a/1.14/s2i/bin/run
+++ b/1.14/s2i/bin/run
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
+
+process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
+
+exec nginx -g "daemon off;"

--- a/1.14/s2i/bin/usage
+++ b/1.14/s2i/bin/usage
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
+
+cat <<EOF
+This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.14/test/test-app/ ${NAMESPACE}/nginx-114-${DISTRO}7 nginx-sample-app
+
+You can then run the resulting image via:
+docker run -p 8080:8080 nginx-sample-app
+EOF

--- a/1.14/test/run
+++ b/1.14/test/run
@@ -1,0 +1,279 @@
+#!/bin/bash
+#
+# The 'run' performs a simple test that verifies that S2I image.
+# The main focus here is to excersise the S2I scripts.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+IMAGE_NAME=${IMAGE_NAME:-rhscl/nginx-114-rhel7}
+
+# TODO: Make command compatible for Mac users
+test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
+image_dir=$(readlink -zf ${test_dir}/..)
+
+. $test_dir/test-lib.sh
+
+# TODO: This should be part of the image metadata
+test_port=8080
+
+info() {
+  echo -e "\n\e[1m[INFO] $@...\e[0m\n"
+}
+
+image_exists() {
+  docker inspect $1 &>/dev/null
+}
+
+container_exists() {
+  image_exists $(cat $cid_file)
+}
+
+container_ip() {
+  docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file)
+}
+
+run_s2i_build() {
+  ct_s2i_build_as_df file://${test_dir}/${1} ${IMAGE_NAME} ${IMAGE_NAME}-${1} ${s2i_args}
+}
+
+prepare() {
+  if ! image_exists ${IMAGE_NAME}; then
+    echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
+    exit 1
+  fi
+  # TODO: S2I build require the application is a valid 'GIT' repository, we
+  # should remove this restriction in the future when a file:// is used.
+  info "Build the test application image"
+  pushd ${test_dir}/${1} >/dev/null
+  git init
+  git config user.email "build@localhost" && git config user.name "builder"
+  git add -A && git commit -m "Sample commit"
+  popd >/dev/null
+}
+
+run_test_application() {
+  run_args=${CONTAINER_ARGS:-}
+  docker run --user=100001 ${run_args} --cidfile=${cid_file} ${IMAGE_NAME}-${1}
+}
+
+cleanup_test_app() {
+  info "Cleaning up the test application"
+  if [ -f $cid_file ]; then
+    if container_exists; then
+      docker stop $(cat $cid_file)
+      docker rm $(cat $cid_file)
+    fi
+    rm $cid_file
+  fi
+}
+
+cleanup() {
+  info "Cleaning up the test application image"
+  if image_exists ${IMAGE_NAME}-${1}; then
+    docker rmi -f ${IMAGE_NAME}-${1}
+  fi
+  rm -rf ${test_dir}/${1}/.git
+}
+
+check_result() {
+  local result="$1"
+  if [[ "$result" != "0" ]]; then
+    info "TEST FAILED (${result})"
+    cleanup $2
+    exit $result
+  fi
+}
+
+wait_for_cid() {
+  local max_attempts=10
+  local sleep_time=1
+  local attempt=1
+  local result=1
+  info "Waiting for application container to start"
+  while [ $attempt -le $max_attempts ]; do
+    [ -f $cid_file ] && [ -s $cid_file ] && break
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+}
+
+test_s2i_usage() {
+  info "Testing 's2i usage'"
+  ct_s2i_usage ${IMAGE_NAME} ${s2i_args} &>/dev/null
+}
+
+test_docker_run_usage() {
+  info "Testing 'docker run' usage"
+  docker run ${IMAGE_NAME} &>/dev/null
+}
+
+test_scl_usage() {
+  local run_cmd="$1"
+  local expected="$2"
+
+  info "Testing the image SCL enable"
+  out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd} 2>&1")
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  test_command "$run_cmd" "$expected"
+  return $?
+}
+
+test_command() {
+  local run_cmd="$1"
+  local expected="$2"
+  local message="$3"
+
+  if [ $message ]; then
+    info ${3}
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/bash -c "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi
+  out=$(docker exec $(cat ${cid_file}) /bin/sh -ic "${run_cmd}" 2>&1)
+  if ! echo "${out}" | grep -q "${expected}"; then
+    echo "ERROR[exec /bin/sh -ic "${run_cmd}"] Expected '${expected}', got '${out}'"
+    return 1
+  fi  
+
+  return 0
+}
+
+test_for_output()
+{
+  local url="$1"
+  local expect="$2"
+  local host="${3-localhost}"
+  local max_attempts=5
+  local sleep_time=1
+  local attempt=1
+  local result=1
+
+  info "Testing URL $url with HTTP hostname ${host} produces output $expect"
+
+  while [ $attempt -le $max_attempts ]; do
+    response=$(curl -s -H "Host: ${host}" ${url})
+    echo "${response}"
+    status=$?
+    if [ $status -eq 0 ]; then
+      if echo "${response}" | grep -q "${expect}"; then
+        info "Success!"
+        result=0
+        break
+      else
+        echo "Response: ${response}"
+      fi
+    fi
+    attempt=$(( $attempt + 1 ))
+    sleep $sleep_time
+  done
+
+  return $result
+}
+
+test_connection() {
+  cat $cid_file
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+
+  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):${test_port}/aliased/index2.html" "NGINX2 is working"  &&
+     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+     return 0
+  fi
+
+  return 1
+}
+
+test_connection_s2i() {
+  cat $cid_file
+  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+
+  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+     return 0
+  fi
+
+  return 1
+}
+
+test_application() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application "test-app" &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_scl_usage "nginx -v" "nginx version: nginx/1.14."
+  check_result $? "test-app"
+
+  test_connection
+  check_result $? "test-app"
+  cleanup_test_app
+}
+
+test_pre_init_script() {
+  # Verify that the HTTP connection can be established to test application container
+  run_test_application "start-hook-test-app" &
+
+  # Wait for the container to write it's CID file
+  wait_for_cid
+
+  test_command "cat /opt/app-root/etc/nginx.d/default.conf | grep 'resolver' | sed -e 's/resolver\(.*\);/\1/' | grep 'DNS_SERVER'" ""
+  check_result $? "start-hook-test-app"
+
+  test_connection_s2i
+  check_result $? "start-hook-test-app"
+  cleanup_test_app
+
+}
+
+cid_file=$(mktemp -u --suffix=.cid)
+
+# Since we built the candidate image locally, we don't want S2I attempt to pull
+# it from Docker hub
+s2i_args="--pull-policy=never"
+
+if [ "$TARGET" == "fedora" ]; then
+  mv ${test_dir}/test-app/nginx.conf{,.bkp}
+  cp ${test_dir}/test-app/nginx.conf{.fedora,}
+fi
+prepare "test-app"
+run_s2i_build "test-app"
+if [ "$TARGET" == "fedora" ]; then
+  mv ${test_dir}/test-app/nginx.conf{.bkp,}
+fi
+check_result $? "test-app"
+
+# Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
+test_s2i_usage
+check_result $? "test-app"
+
+# Verify the 'usage' script is working properly when running the base image with 'docker run ...'
+test_docker_run_usage
+check_result $? "test-app"
+
+# Test application with default uid
+test_application 
+
+# Test application with random uid
+CONTAINER_ARGS="--user 12345" test_application
+cleanup "test-app"
+
+# Test start-hook script functionality
+cid_file=$(mktemp -u --suffix=.cid)
+
+prepare "start-hook-test-app"
+run_s2i_build "start-hook-test-app"
+check_result $? "start-hook-test-app"
+
+test_pre_init_script
+cleanup "start-hook-test-app"
+
+info "All tests finished successfully."

--- a/1.14/test/run-openshift
+++ b/1.14/test/run-openshift
@@ -1,0 +1,1 @@
+../../test/run-openshift

--- a/1.14/test/start-hook-test-app/index.html
+++ b/1.14/test/start-hook-test-app/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX is working</h1>
+</body>
+</html>

--- a/1.14/test/start-hook-test-app/index2.html
+++ b/1.14/test/start-hook-test-app/index2.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX2 is working</h1>
+</body>
+</html>

--- a/1.14/test/start-hook-test-app/nginx-cfg/default.conf
+++ b/1.14/test/start-hook-test-app/nginx-cfg/default.conf
@@ -1,0 +1,8 @@
+server {
+	listen       8080;
+	server_name  localhost2;
+	root         /opt/app-root/src;
+	index        ${INDEX_FILE};
+	resolver ${DNS_SERVER};
+
+}

--- a/1.14/test/start-hook-test-app/nginx-start/init.sh
+++ b/1.14/test/start-hook-test-app/nginx-start/init.sh
@@ -1,0 +1,19 @@
+setup_dns_env_var() {
+	if [ -z "$DNS_SERVER" ]; then
+	    export DNS_SERVER=`cat /etc/resolv.conf | grep "nameserver " | awk '{print $2}' | tr '\n' ' '`
+	    echo "Using system dns server ${DNS_SERVER}"
+	else
+	    echo "Using user defined dns server: ${DNS_SERVER}"
+	fi  
+}
+
+inject_env_vars() {
+	## Replace only specified environment variables in specified file.
+	envsubst '${DNS_SERVER},${INDEX_FILE}' < ${NGINX_CONFIGURATION_PATH}/$1 > output.conf
+	cp output.conf ${NGINX_CONFIGURATION_PATH}/$1
+	echo "This is $1: " && cat ${NGINX_CONFIGURATION_PATH}/$1
+}
+
+export INDEX_FILE=index2.html
+setup_dns_env_var
+inject_env_vars "default.conf"

--- a/1.14/test/test-app
+++ b/1.14/test/test-app
@@ -1,0 +1,1 @@
+../../examples/1.14/test-app

--- a/1.14/test/test-lib-openshift.sh
+++ b/1.14/test/test-lib-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-openshift.sh

--- a/1.14/test/test-lib.sh
+++ b/1.14/test/test-lib.sh
@@ -1,0 +1,1 @@
+../../common/test-lib.sh

--- a/examples/1.14/test-app/index.html
+++ b/examples/1.14/test-app/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX is working</h1>
+</body>
+</html>

--- a/examples/1.14/test-app/index2.html
+++ b/examples/1.14/test-app/index2.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX2 is working</h1>
+</body>
+</html>

--- a/examples/1.14/test-app/nginx-cfg/default.conf
+++ b/examples/1.14/test-app/nginx-cfg/default.conf
@@ -1,0 +1,6 @@
+server {
+	listen       8080;
+	server_name  localhost2;
+	root         /opt/app-root/src;
+	index        index2.html;
+}

--- a/examples/1.14/test-app/nginx-default-cfg/alias.conf
+++ b/examples/1.14/test-app/nginx-default-cfg/alias.conf
@@ -1,0 +1,3 @@
+location /aliased/ {
+         alias /opt/app-root/src/;
+}

--- a/examples/1.14/test-app/nginx.conf
+++ b/examples/1.14/test-app/nginx.conf
@@ -1,0 +1,117 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+
+worker_processes auto;
+error_log stderr;
+pid /var/opt/rh/rh-nginx114/run/nginx/nginx.pid;
+
+# Load dynamic modules. See /opt/rh/rh-nginx114/root/usr/share/doc/README.dynamic.
+include /opt/rh/rh-nginx114/root/usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout  65;
+    types_hash_max_size 2048;
+
+    include       /etc/opt/rh/rh-nginx114/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include      /opt/app-root/etc/nginx.default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+        location = /40x.html {
+        }
+
+        error_page 500 502 503 504  /50x.html;
+        location = /50x.html {
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:8080
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+
+    # another virtual host using mix of IP-, name-, and port-based configuration
+    #
+    #server {
+    #    listen       808000;
+    #    listen       somename:808080;
+    #    server_name  somename  alias  another.alias;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+
+    # HTTPS server
+    #
+    #server {
+    #    listen       443;
+    #    server_name  localhost;
+
+    #    ssl                  on;
+    #    ssl_certificate      cert.pem;
+    #    ssl_certificate_key  cert.key;
+
+    #    ssl_session_timeout  5m;
+
+    #    ssl_protocols  SSLv2 SSLv3 TLSv1;
+    #    ssl_ciphers  HIGH:!aNULL:!MD5;
+    #    ssl_prefer_server_ciphers   on;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+}

--- a/examples/1.14/test-app/nginx.conf.fedora
+++ b/examples/1.14/test-app/nginx.conf.fedora
@@ -25,7 +25,7 @@ http {
     tcp_nopush          on;
     tcp_nodelay         on;
     keepalive_timeout   65;
-    types_hash_max_size 2048;
+    types_hash_max_size 4096;
 
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;

--- a/examples/1.14/test-app/nginx.conf.fedora
+++ b/examples/1.14/test-app/nginx.conf.fedora
@@ -1,0 +1,90 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+
+worker_processes auto;
+error_log stderr;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include /opt/app-root/etc/nginx.default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2 default_server;
+#        listen       [::]:443 ssl http2 default_server;
+#        server_name  _;
+#        root         /opt/app-root/src;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers PROFILE=SYSTEM;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /opt/app-root/etc/nginx.default.d/*.conf;
+#
+#        location / {
+#        }
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+}
+


### PR DESCRIPTION
As the title implies, this PR adds an Nginx 1.14 container build and S2I capability. In addition, I made some changes to the Fedora image handling to properly install the specified version of Nginx (in this case 1.14) regardless of which version of Fedora the image is built against (this assumes that the version of Fedora still contains that specific version of Nginx in its repo).

I was able to test both the Centos and Fedora builds but not the RHEL build (don't have access to an entitled RHEL build box).