### PR TITLE
Replace docker cp with docker exec <cont> cat

### DIFF
--- a/1.10/test/run
+++ b/1.10/test/run
@@ -161,8 +161,8 @@ test_logs() {
   elif [ "x$logfile" = "xstderr" ]; then
       out=$(docker logs $(cat ${cid_file}) 2>&1 1>/dev/null)
   elif [ -n "$logfile" ]; then
-      info "Extracting $logfile via docker cp..."
-      out=$(docker cp $(cat ${cid_file}):${logfile} - | tar -xO '*')
+      info "Extracting $logfile via docker exec <cont> cat ${logfile}..."
+      out=$(docker exec $(cat ${cid_file}) cat ${logfile})
   else
       out=$(docker logs $(cat ${cid_file}) 2>&1)
   fi

--- a/1.12/test/run
+++ b/1.12/test/run
@@ -161,8 +161,8 @@ test_logs() {
   elif [ "x$logfile" = "xstderr" ]; then
       out=$(docker logs $(cat ${cid_file}) 2>&1 1>/dev/null)
   elif [ -n "$logfile" ]; then
-      info "Extracting $logfile via docker cp..."
-      out=$(docker cp $(cat ${cid_file}):${logfile} - | tar -xO '*')
+      info "Extracting $logfile via docker exec <cont> cat ${logfile}..."
+      out=$(docker exec $(cat ${cid_file}) cat ${logfile})
   else
       out=$(docker logs $(cat ${cid_file}) 2>&1)
   fi

--- a/1.14/test/run
+++ b/1.14/test/run
@@ -161,8 +161,8 @@ test_logs() {
   elif [ "x$logfile" = "xstderr" ]; then
       out=$(docker logs $(cat ${cid_file}) 2>&1 1>/dev/null)
   elif [ -n "$logfile" ]; then
-      info "Extracting $logfile via docker cp..."
-      out=$(docker cp $(cat ${cid_file}):${logfile} - | tar -xO '*')
+      info "Extracting $logfile via docker exec <cont> cat ${logfile}..."
+      out=$(docker exec $(cat ${cid_file}) cat ${logfile})
   else
       out=$(docker logs $(cat ${cid_file}) 2>&1)
   fi


### PR DESCRIPTION
When running with podman older than 1.1.0, which does not have cp command,
the test failed. This way the test does pretty much the same thing, but allows
to run it successfully with older podman as well.