### PR TITLE
Fix persmissions for all files given in s2i

### DIFF
--- a/1.10/s2i/bin/assemble
+++ b/1.10/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-cp -Rf /tmp/src/. ./
+mv /tmp/src/* ./
 
 # Fix source directory permissions
 fix-permissions ./
@@ -11,7 +11,7 @@ fix-permissions ./
 if [ -d ./nginx-cfg ]; then
   echo "---> Copying nginx configuration files..."
   if [ "$(ls -A ./nginx-cfg/*.conf)" ]; then
-    cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+    cp -av ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
   chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
@@ -20,7 +20,7 @@ fi
 if [ -d ./nginx-default-cfg ]; then
   echo "---> Copying nginx default server configuration files..."
   if [ "$(ls -A ./nginx-default-cfg/*.conf)" ]; then
-    cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+    cp -av ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
     rm -rf ./nginx-default-cfg
   fi
   chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
@@ -29,7 +29,7 @@ fi
 if [ -d ./nginx-start ]; then
   echo "---> Copying nginx start-hook scripts..."
   if [ "$(ls -A ./nginx-start/* 2>/dev/null)" ]; then
-    cp -v ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
+    cp -av ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
     rm -rf ./nginx-start
   fi
 fi

--- a/1.10/s2i/bin/assemble
+++ b/1.10/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-mv /tmp/src/* ./
+cp -Rf /tmp/src/. ./
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.10/s2i/bin/assemble
+++ b/1.10/s2i/bin/assemble
@@ -5,6 +5,9 @@ set -e
 echo "---> Installing application source"
 cp -Rf /tmp/src/. ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -d ./nginx-cfg ]; then
   echo "---> Copying nginx configuration files..."
   if [ "$(ls -A ./nginx-cfg/*.conf)" ]; then
@@ -30,6 +33,3 @@ if [ -d ./nginx-start ]; then
     rm -rf ./nginx-start
   fi
 fi
-
-# Fix source directory permissions
-fix-permissions ./

--- a/1.12/Dockerfile.fedora
+++ b/1.12/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f26/s2i-core:latest
+FROM registry.fedoraproject.org/f31/s2i-core:latest
 
 # nginx 1.12 image.
 #
@@ -43,6 +43,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_LOG_PATH=/var/log/nginx
 
 RUN dnf install -y gettext hostname && \
+    dnf -y module enable nginx:$NGINX_VERSION && \
     INSTALL_PKGS="nss_wrapper bind-utils nginx nginx-mod-stream" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/1.12/s2i/bin/assemble
+++ b/1.12/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-cp -Rf /tmp/src/. ./
+mv /tmp/src/* ./
 
 # Fix source directory permissions
 fix-permissions ./
@@ -17,7 +17,7 @@ fi
 if [ -d ./nginx-cfg ]; then
   echo "---> Copying nginx configuration files..."
   if [ "$(ls -A ./nginx-cfg/*.conf)" ]; then
-    cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+    cp -av ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
   chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
@@ -26,7 +26,7 @@ fi
 if [ -d ./nginx-default-cfg ]; then
   echo "---> Copying nginx default server configuration files..."
   if [ "$(ls -A ./nginx-default-cfg/*.conf)" ]; then
-    cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+    cp -av ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
     rm -rf ./nginx-default-cfg
   fi
   chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
@@ -35,7 +35,7 @@ fi
 if [ -d ./nginx-start ]; then
   echo "---> Copying nginx start-hook scripts..."
   if [ "$(ls -A ./nginx-start/* 2>/dev/null)" ]; then
-    cp -v ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
+    cp -av ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
     rm -rf ./nginx-start
   fi
 fi

--- a/1.12/s2i/bin/assemble
+++ b/1.12/s2i/bin/assemble
@@ -5,6 +5,9 @@ set -e
 echo "---> Installing application source"
 cp -Rf /tmp/src/. ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -f ./nginx.conf ]; then
   echo "---> Copying nginx.conf configuration file..."
   cp -v ./nginx.conf "${NGINX_CONF_PATH}"
@@ -36,6 +39,3 @@ if [ -d ./nginx-start ]; then
     rm -rf ./nginx-start
   fi
 fi
-
-# Fix source directory permissions
-fix-permissions ./

--- a/1.12/s2i/bin/assemble
+++ b/1.12/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-mv /tmp/src/* ./
+cp -Rf /tmp/src/. ./
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.14/Dockerfile.fedora
+++ b/1.14/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/s2i-core:latest
+FROM registry.fedoraproject.org/f31/s2i-core:latest
 
 # nginx 1.14 image.
 #
@@ -43,6 +43,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_LOG_PATH=/var/log/nginx
 
 RUN dnf install -y gettext hostname && \
+    dnf -y module enable nginx:$NGINX_VERSION && \
     INSTALL_PKGS="nss_wrapper bind-utils nginx nginx-mod-stream" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/1.14/s2i/bin/assemble
+++ b/1.14/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-cp -Rf /tmp/src/. ./
+mv /tmp/src/* ./
 
 # Fix source directory permissions
 fix-permissions ./
@@ -17,7 +17,7 @@ fi
 if [ -d ./nginx-cfg ]; then
   echo "---> Copying nginx configuration files..."
   if [ "$(ls -A ./nginx-cfg/*.conf)" ]; then
-    cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+    cp -av ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
   chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
@@ -26,7 +26,7 @@ fi
 if [ -d ./nginx-default-cfg ]; then
   echo "---> Copying nginx default server configuration files..."
   if [ "$(ls -A ./nginx-default-cfg/*.conf)" ]; then
-    cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+    cp -av ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
     rm -rf ./nginx-default-cfg
   fi
   chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
@@ -35,7 +35,7 @@ fi
 if [ -d ./nginx-start ]; then
   echo "---> Copying nginx start-hook scripts..."
   if [ "$(ls -A ./nginx-start/* 2>/dev/null)" ]; then
-    cp -v ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
+    cp -av ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
     rm -rf ./nginx-start
   fi
 fi

--- a/1.14/s2i/bin/assemble
+++ b/1.14/s2i/bin/assemble
@@ -5,6 +5,9 @@ set -e
 echo "---> Installing application source"
 cp -Rf /tmp/src/. ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -f ./nginx.conf ]; then
   echo "---> Copying nginx.conf configuration file..."
   cp -v ./nginx.conf "${NGINX_CONF_PATH}"
@@ -36,6 +39,3 @@ if [ -d ./nginx-start ]; then
     rm -rf ./nginx-start
   fi
 fi
-
-# Fix source directory permissions
-fix-permissions ./

--- a/1.14/s2i/bin/assemble
+++ b/1.14/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-mv /tmp/src/* ./
+cp -Rf /tmp/src/* ./
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.14/s2i/bin/assemble
+++ b/1.14/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-cp -Rf /tmp/src/* ./
+cp -Rf /tmp/src/. ./
 
 # Fix source directory permissions
 fix-permissions ./

--- a/1.16/s2i/bin/assemble
+++ b/1.16/s2i/bin/assemble
@@ -5,6 +5,9 @@ set -e
 echo "---> Installing application source"
 cp -Rf /tmp/src/. ./
 
+# Fix source directory permissions
+fix-permissions ./
+
 if [ -f ./nginx.conf ]; then
   echo "---> Copying nginx.conf configuration file..."
   cp -v ./nginx.conf "${NGINX_CONF_PATH}"
@@ -14,7 +17,7 @@ fi
 if [ -d ./nginx-cfg ]; then
   echo "---> Copying nginx configuration files..."
   if [ "$(ls -A ./nginx-cfg/*.conf)" ]; then
-    cp -v ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+    cp -av ./nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
     rm -rf ./nginx-cfg
   fi
   chmod -Rf g+rw ${NGINX_CONFIGURATION_PATH}
@@ -23,7 +26,7 @@ fi
 if [ -d ./nginx-default-cfg ]; then
   echo "---> Copying nginx default server configuration files..."
   if [ "$(ls -A ./nginx-default-cfg/*.conf)" ]; then
-    cp -v ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+    cp -av ./nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
     rm -rf ./nginx-default-cfg
   fi
   chmod -Rf g+rw ${NGINX_DEFAULT_CONF_PATH}
@@ -32,10 +35,7 @@ fi
 if [ -d ./nginx-start ]; then
   echo "---> Copying nginx start-hook scripts..."
   if [ "$(ls -A ./nginx-start/* 2>/dev/null)" ]; then
-    cp -v ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
+    cp -av ./nginx-start/* "${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start/"
     rm -rf ./nginx-start
   fi
 fi
-
-# Fix source directory permissions
-fix-permissions ./


### PR DESCRIPTION
Otherwise we can see permissions denied in cases the files copied into
/usr/share did not have correct permissions on the host originaly.

It looked like this in the test log:
/usr/share/container-scripts/nginx/common.sh: line 33: /usr/share/container-scripts/nginx/nginx-start/init.sh: Permission denied