### PR TITLE
Update imagestreams

### DIFF
--- a/imagestreams/nginx-rhel7-ppc64le.json
+++ b/imagestreams/nginx-rhel7-ppc64le.json
@@ -11,6 +11,26 @@
     "tags": [
       {
         "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx,ppc64le",
+          "version": "1.16"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/nginx-116-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.16"
+      },
+      {
+        "annotations": {
           "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14",
@@ -31,26 +51,6 @@
       },
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.10/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.10",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx,ppc64le",
-          "version": "1.10"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/nginx-110-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.10"
-      },
-      {
-        "annotations": {
           "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
@@ -61,7 +61,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.14"
+          "name": "1.16"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nginx-rhel7.json
+++ b/imagestreams/nginx-rhel7.json
@@ -11,6 +11,26 @@
     "tags": [
       {
         "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.16"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/nginx-116-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.16"
+      },
+      {
+        "annotations": {
           "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14",
@@ -61,7 +81,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.14"
+          "name": "1.16"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
1.16 has been released.  1.10 was never supported on ppc64le.