### PR TITLE
Reorder imagestreams

### DIFF
--- a/imagestreams/nginx-centos7.json
+++ b/imagestreams/nginx-centos7.json
@@ -11,23 +11,22 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
           "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.14"
+          "tags": "builder,nginx"
         },
         "from": {
-          "kind": "DockerImage",
-          "name": "docker.io/centos/nginx-114-centos7:latest"
+          "kind": "ImageStreamTag",
+          "name": "1.16"
         },
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "1.14"
+        "name": "latest"
       },
       {
         "annotations": {
@@ -51,22 +50,23 @@
       },
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
           "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
           "supports": "nginx",
-          "tags": "builder,nginx"
+          "tags": "builder,nginx",
+          "version": "1.14"
         },
         "from": {
-          "kind": "ImageStreamTag",
-          "name": "1.16"
+          "kind": "DockerImage",
+          "name": "docker.io/centos/nginx-114-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "latest"
+        "name": "1.14"
       }
     ]
   }

--- a/imagestreams/nginx-rhel7-ppc64le.json
+++ b/imagestreams/nginx-rhel7-ppc64le.json
@@ -11,6 +11,25 @@
     "tags": [
       {
         "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx,ppc64le"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "1.16"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "latest"
+      },
+      {
+        "annotations": {
           "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
@@ -48,25 +67,6 @@
           "type": "Local"
         },
         "name": "1.14"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx,ppc64le"
-        },
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "1.16"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "latest"
       }
     ]
   }

--- a/imagestreams/nginx-rhel7-s390x.json
+++ b/imagestreams/nginx-rhel7-s390x.json
@@ -11,6 +11,25 @@
     "tags": [
       {
         "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx,s390x"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "1.16"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "latest"
+      },
+      {
+        "annotations": {
           "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
@@ -48,25 +67,6 @@
           "type": "Local"
         },
         "name": "1.14"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx,s390x"
-        },
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "1.16"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "latest"
       }
     ]
   }

--- a/imagestreams/nginx-rhel7.json
+++ b/imagestreams/nginx-rhel7.json
@@ -11,6 +11,25 @@
     "tags": [
       {
         "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "1.16"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "latest"
+      },
+      {
+        "annotations": {
           "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
@@ -48,25 +67,6 @@
           "type": "Local"
         },
         "name": "1.14"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx"
-        },
-        "from": {
-          "kind": "ImageStreamTag",
-          "name": "1.16"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "latest"
       }
     ]
   }


### PR DESCRIPTION
Order is now: latest, 1.16, and 1.14.

We would like to test if the latest version is present in the imagestreams.
It is done by ansible-script (sclorg/ansible-tests#4)

The second tag is going to be used for test if the version is the latest.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>