### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/1.12/test/imagestreams
+++ b/1.12/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams/

--- a/1.14/test/imagestreams
+++ b/1.14/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams/

--- a/1.16/test/imagestreams
+++ b/1.16/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams/

--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -10,6 +10,7 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib.sh
 source ${THISDIR}/test-lib-openshift.sh
+source ${THISDIR}/test-lib-nginx.sh
 
 # TODO: branch should be changed to master, once code in example app
 # stabilizes on with referencing latest version
@@ -17,8 +18,11 @@ BRANCH_TO_TEST=master
 
 set -eo nounset
 
-test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
-test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+trap ct_os_cleanup EXIT SIGINT
+
+ct_os_check_compulsory_vars
+
+ct_os_enable_print_logs
 
 ct_os_cluster_up
 
@@ -34,4 +38,13 @@ ct_os_test_template_app ${IMAGE_NAME} \
                         nginx \
                         'Welcome to your static nginx application on OpenShift' \
                         8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
+
+# Check the imagestream
+test_nginx_imagestream
+
+OS_TESTSUITE_RESULT=0
+
+ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,12 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_nginx_integration nginx ${VERSION} "${IMAGE_NAME}"
+test_nginx_integration "${IMAGE_NAME}" ${VERSION} nginx
+
+# Check the imagestream
+test_nginx_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,7 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_nginx_integration "${IMAGE_NAME}" ${VERSION} nginx
+test_nginx_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_nginx_imagestream

--- a/test/test-lib-nginx.sh
+++ b/test/test-lib-nginx.sh
@@ -13,12 +13,10 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_nginx_integration() {
   local image_name=$1
-  local version=$2
-  local import_image=$3
-  VERSION=$version ct_os_test_s2i_app "${image_name}" \
-                                      "https://github.com/sclorg/nginx-container.git" \
-                                      "examples/${version}/test-app" \
-                                      "Test NGINX passed"
+  ct_os_test_s2i_app "${image_name}" \
+                     "https://github.com/sclorg/nginx-container.git" \
+                     "examples/${VERSION}/test-app" \
+                     "Test NGINX passed"
 }
 
 # Check the imagestream

--- a/test/test-lib-nginx.sh
+++ b/test/test-lib-nginx.sh
@@ -17,10 +17,20 @@ function test_nginx_integration() {
   local import_image=$3
   VERSION=$version ct_os_test_s2i_app "${image_name}" \
                                       "https://github.com/sclorg/nginx-container.git" \
-                                      examples/${version}/test-app \
-                                      "Test NGINX passed" \
-                                      8080 http 200 "" \
-                                      "${import_image}"
+                                      "examples/${version}/test-app" \
+                                      "Test NGINX passed"
 }
 
+# Check the imagestream
+function test_nginx_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/nginx-${OS}.json" "${IMAGE_NAME}" \
+                              "https://github.com/sclorg/nginx-container.git" \
+                              "examples/${VERSION}/test-app" \
+                              "Test NGINX passed"
+}
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -1,0 +1,1 @@
+../common/test-lib.sh


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster
