### PR TITLE
Add CentOS 8 image streams

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -21,12 +21,32 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.16-el7"
+          "name": "1.16-el8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16 (CentOS 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.16"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/centos/nginx-116-centos7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.16-el8"
       },
       {
         "annotations": {
@@ -67,6 +87,26 @@
           "type": "Local"
         },
         "name": "1.16"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14 (CentOS 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.14"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/centos/nginx-114-centos8:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.14-el8"
       },
       {
         "annotations": {


### PR DESCRIPTION
Let's do not merge yet, there are ongoing discussions whether nginx container image is gonna be released as a UBI -- in that case, we can avoid building CentOS 8 images.