### PR TITLE
 Document usage with a Dockerfile

### DIFF
--- a/1.16/README.md
+++ b/1.16/README.md
@@ -9,6 +9,7 @@ The resulting image can be run using [podman](https://github.com/containers/libp
 
 Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments.
 
+
 Description
 -----------
 
@@ -19,34 +20,38 @@ as a base image for other applications based on nginx 1.16 web server.
 Nginx server image can be extended using Openshift's `Source` build feature.
 
 
-Usage
------
+Usage in OpenShift
+------------------
+In this example, we assume that you are using the `rhel8/nginx-116` image, available through the `nginx:1.16` imagestream tag in Openshift.
+To build a simple [test-app](https://github.com/sclorg/nginx-container/tree/master/examples/1.16/test-app) application in Openshift:
 
-For this, we will assume that you are using the `rhel8/nginx-116` image, available via `nginx:1.16` imagestream tag in Openshift.
-Building a simple [sample-app](https://github.com/sclorg/nginx-container/tree/master/1.16/test/test-app) application
-in Openshift can be achieved with the following step:
-
-    ```
-    oc new-app nginx:1.16~https://github.com/sclorg/nginx-container.git --context-dir=1.16/test/test-app/
-    ```
-
-The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
-
-    ```
-    $ s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.16/test/test-app/ rhel8/nginx-116 nginx-sample-app
-    ```
-
-**Accessing the application:**
 ```
-$ curl 127.0.0.1:8080
+oc new-app nginx:1.16~https://github.com/sclorg/nginx-container.git --context-dir=1.16/test/test-app/
+```
+
+To access the application:
+```
+$ oc get pods
+$ oc exec <pod> -- curl 127.0.0.1:8080
 ```
 
 
-S2I build support
------------------
-This image can be extended in Openshift using the `Source` build strategy or via the standalone
-[source-to-image](https://github.com/openshift/source-to-image) application (where available).
-S2I build folder structure:
+Source-to-Image framework and scripts
+-------------------------------------
+This image supports the [Source-to-Image](https://docs.openshift.com/container-platform/4.4/builds/build-strategies.html#images-create-s2i_build-strategies)
+(S2I) strategy in OpenShift. The Source-to-Image is an OpenShift framework
+which makes it easy to write images that take application source code as
+an input, use a builder image like this Nginx container image, and produce
+a new image that runs the assembled application as an output.
+
+In case of Nginx container image, the application source code is typically
+either static HTML pages or configuration files.
+
+To support the Source-to-Image framework, important scripts are included in the builder image:
+
+* The `/usr/libexec/s2i/run` script is set as the default command in the resulting container image (the new image with the application artifacts).
+
+* The `/usr/libexec/s2i/assemble` script inside the image is run to produce a new image with the application artifacts. The script takes sources of a given application (HTML pages), Nginx configuration files, and places them into appropriate directories inside the image. The structure of nginx-app can look like this:
 
 **`./nginx.conf`**--
        The main nginx configuration file
@@ -67,6 +72,110 @@ S2I build folder structure:
        Should contain nginx application source code
 
 
+Build an application using a Dockerfile
+---------------------------------------
+Compared to the Source-to-Image strategy, using a Dockerfile is a more
+flexible way to build an Nginx container image with an application.
+Use a Dockerfile when Source-to-Image is not sufficiently flexible for you or
+when you build the image outside of the OpenShift environment.
+
+To use the Nginx image in a Dockerfile, follow these steps:
+
+#### 1. Pull a base builder image to build on
+
+podman pull rhel8/nginx-116
+
+#### 2. Pull an application code
+
+An example application available at https://github.com/sclorg/nginx-container.git is used here. To adjust the example application, clone the repository.
+
+```
+git clone https://github.com/sclorg/nginx-container.git nginx-container
+cd nginx-container/examples/1.16/
+```
+
+#### 3. Prepare an application inside a container
+
+This step usually consists of at least these parts:
+
+* putting the application source into the container
+* moving configuration files to the correct place (if available in the application source code)
+* setting the default command in the resulting image
+
+For all these three parts, you can either set up all manually and use the `nginx` command explicitly in the Dockerfile ([3.1.](#31-to-use-own-setup-create-a-dockerfile-with-this-content)), or you can use the Source-to-Image scripts inside the image ([3.2.](#32-to-use-the-source-to-image-scripts-and-build-an-image-using-a-dockerfile-create-a-dockerfile-with-this-content). For more information about these scripts, which enable you to set-up and run the nginx daemon, see the "Source-to-Image framework and scripts" section above.
+
+##### 3.1. To use your own setup, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-116
+
+# Add application sources
+ADD test-app/nginx.conf "${NGINX_CONF_PATH}"
+ADD test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+ADD test-app/*.html .
+
+# Run script uses standard ways to run the application
+CMD nginx -g "daemon off;"
+```
+
+##### 3.2. To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-116
+
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+USER 0
+ADD test-app /tmp/src/
+RUN chown -R 1001:0 /tmp/src
+USER 1001
+
+# Let the assemble script to install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Run script uses standard ways to run the application
+CMD /usr/libexec/s2i/run
+```
+
+#### 4. Build a new image from a Dockerfile prepared in the previous step
+```
+podman build -t nginx-app .
+```
+
+#### 5. Run the resulting image with the final application
+```
+podman run -d nginx-app
+```
+
+
+Direct usage with a mounted directory
+-------------------------------------
+An example of the data on the host for the following example:
+```
+$ ls -lZ /wwwdata/html
+-rw-r--r--. 1 1001 1001 54321 Jan 01 12:34 index.html
+-rw-r--r--. 1 1001 1001  5678 Jan 01 12:34 page.html
+```
+
+If you want to run the image directly and mount the static pages available in the `/wwwdata/` directory on the host
+as a container volume, execute the following command:
+
+```
+$ podman run -d --name nginx -p 8080:8080 -v /wwwdata:/opt/app-root/src:Z rhel8/nginx-116 nginx -g "daemon off;"
+```
+
+This creates a container named `nginx` running the Nginx server, serving data from
+the `/wwwdata/` directory. Port 8080 is exposed and mapped to the host.
+You can pull the data from the nginx container using this command:
+
+```
+$ curl -Lk 127.0.0.1:8080
+```
+
+You can replace `/wwwdata/` with location of your web root. Please note that this has to be an **absolute** path, due to podman requirements.
+
+
 Environment variables and volumes
 ---------------------------------
 The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
@@ -74,13 +183,6 @@ The nginx container image supports the following configuration variable, which c
 
 **`NGINX_LOG_TO_VOLUME`**
        When `NGINX_LOG_TO_VOLUME` is set, nginx logs into `/var/log/nginx/`. In case of RHEL-7 and CentOS-7 images, this is a symlink to `/var/opt/rh/rh-nginx116/log/nginx/`.
-
-
-You can mount your own web root like this:
-```
-$ podman run -v <DIR>:/var/www/html/ <container>
-```
-You can replace \<DIR> with location of your web root. Please note that this has to be an **absolute** path, due to podman requirements.
 
 
 Troubleshooting

--- a/1.16/s2i/bin/usage
+++ b/1.16/s2i/bin/usage
@@ -1,17 +1,19 @@
 #!/bin/sh
 
 DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
-NAMESPACE=centos
-[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
 
 cat <<EOF
-This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image:
-To use it, install S2I: https://github.com/openshift/source-to-image
+This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image.
 
-Sample invocation:
+To use it in OpenShift, run:
 
-s2i build https://github.com/sclorg/nginx-container.git --context-dir=${NGINX_VERSION}/test/test-app/ ${NAMESPACE}/nginx-${NGINX_SHORT_VER}-${DISTRO}7 nginx-sample-app
+  oc new-app nginx:${NGINX_VERSION}~https://github.com/sclorg/nginx-container.git --context-dir=${NGINX_VERSION}/test/test-app/
 
 You can then run the resulting image via:
-docker run -p 8080:8080 nginx-sample-app
+
+  docker run -p 8080:8080 nginx-sample-app
+
+Alternatively, to run the image directly using podman or docker, or how to use it as a parent image in a Dockerfile, see documentation at
+
+  https://github.com/sclorg/nginx-container/blob/master/${NGINX_VERSION}/README.md.
 EOF

--- a/1.18/README.md
+++ b/1.18/README.md
@@ -22,7 +22,7 @@ Nginx server image can be extended using Openshift's `Source` build feature.
 
 Usage in OpenShift
 ------------------
-In this example, we assume that you are using the `rhel8/nginx-118` image, available through the `nginx:1.18` imagestream tag in Openshift.
+In this example, we assume that you are using the `ubi8/nginx-118` image, available through the `nginx:1.18` imagestream tag in Openshift.
 To build a simple [test-app](https://github.com/sclorg/nginx-container/tree/master/examples/1.18/test-app) application in Openshift:
 
 ```
@@ -83,7 +83,7 @@ To use the Nginx image in a Dockerfile, follow these steps:
 
 #### 1. Pull a base builder image to build on
 
-podman pull rhel8/nginx-118
+podman pull ubi8/nginx-118
 
 #### 2. Pull an application code
 
@@ -162,7 +162,7 @@ If you want to run the image directly and mount the static pages available in th
 as a container volume, execute the following command:
 
 ```
-$ podman run -d --name nginx -p 8080:8080 -v /wwwdata:/opt/app-root/src:Z rhel8/nginx-118 nginx -g "daemon off;"
+$ podman run -d --name nginx -p 8080:8080 -v /wwwdata:/opt/app-root/src:Z ubi8/nginx-118 nginx -g "daemon off;"
 ```
 
 This creates a container named `nginx` running the Nginx server, serving data from

--- a/1.18/README.md
+++ b/1.18/README.md
@@ -9,6 +9,7 @@ The resulting image can be run using [podman](https://github.com/containers/libp
 
 Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments.
 
+
 Description
 -----------
 
@@ -19,34 +20,38 @@ as a base image for other applications based on nginx 1.18 web server.
 Nginx server image can be extended using Openshift's `Source` build feature.
 
 
-Usage
------
+Usage in OpenShift
+------------------
+In this example, we assume that you are using the `rhel8/nginx-118` image, available through the `nginx:1.18` imagestream tag in Openshift.
+To build a simple [test-app](https://github.com/sclorg/nginx-container/tree/master/examples/1.18/test-app) application in Openshift:
 
-For this, we will assume that you are using the `rhel8/nginx-118` image, available via `nginx:1.18` imagestream tag in Openshift.
-Building a simple [sample-app](https://github.com/sclorg/nginx-container/tree/master/1.18/test/test-app) application
-in Openshift can be achieved with the following step:
-
-    ```
-    oc new-app nginx:1.18~https://github.com/sclorg/nginx-container.git --context-dir=1.18/test/test-app/
-    ```
-
-The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
-
-    ```
-    $ s2i build https://github.com/sclorg/nginx-container.git --context-dir=1.18/test/test-app/ rhel8/nginx-118 nginx-sample-app
-    ```
-
-**Accessing the application:**
 ```
-$ curl 127.0.0.1:8080
+oc new-app nginx:1.18~https://github.com/sclorg/nginx-container.git --context-dir=1.18/test/test-app/
+```
+
+To access the application:
+```
+$ oc get pods
+$ oc exec <pod> -- curl 127.0.0.1:8080
 ```
 
 
-S2I build support
------------------
-This image can be extended in Openshift using the `Source` build strategy or via the standalone
-[source-to-image](https://github.com/openshift/source-to-image) application (where available).
-S2I build folder structure:
+Source-to-Image framework and scripts
+-------------------------------------
+This image supports the [Source-to-Image](https://docs.openshift.com/container-platform/4.4/builds/build-strategies.html#images-create-s2i_build-strategies)
+(S2I) strategy in OpenShift. The Source-to-Image is an OpenShift framework
+which makes it easy to write images that take application source code as
+an input, use a builder image like this Nginx container image, and produce
+a new image that runs the assembled application as an output.
+
+In case of Nginx container image, the application source code is typically
+either static HTML pages or configuration files.
+
+To support the Source-to-Image framework, important scripts are included in the builder image:
+
+* The `/usr/libexec/s2i/run` script is set as the default command in the resulting container image (the new image with the application artifacts).
+
+* The `/usr/libexec/s2i/assemble` script inside the image is run to produce a new image with the application artifacts. The script takes sources of a given application (HTML pages), Nginx configuration files, and places them into appropriate directories inside the image. The structure of nginx-app can look like this:
 
 **`./nginx.conf`**--
        The main nginx configuration file
@@ -67,6 +72,110 @@ S2I build folder structure:
        Should contain nginx application source code
 
 
+Build an application using a Dockerfile
+---------------------------------------
+Compared to the Source-to-Image strategy, using a Dockerfile is a more
+flexible way to build an Nginx container image with an application.
+Use a Dockerfile when Source-to-Image is not sufficiently flexible for you or
+when you build the image outside of the OpenShift environment.
+
+To use the Nginx image in a Dockerfile, follow these steps:
+
+#### 1. Pull a base builder image to build on
+
+podman pull rhel8/nginx-118
+
+#### 2. Pull an application code
+
+An example application available at https://github.com/sclorg/nginx-container.git is used here. To adjust the example application, clone the repository.
+
+```
+git clone https://github.com/sclorg/nginx-container.git nginx-container
+cd nginx-container/examples/1.18/
+```
+
+#### 3. Prepare an application inside a container
+
+This step usually consists of at least these parts:
+
+* putting the application source into the container
+* moving configuration files to the correct place (if available in the application source code)
+* setting the default command in the resulting image
+
+For all these three parts, you can either set up all manually and use the `nginx` command explicitly in the Dockerfile ([3.1.](#31-to-use-own-setup-create-a-dockerfile-with-this-content)), or you can use the Source-to-Image scripts inside the image ([3.2.](#32-to-use-the-source-to-image-scripts-and-build-an-image-using-a-dockerfile-create-a-dockerfile-with-this-content). For more information about these scripts, which enable you to set-up and run the nginx daemon, see the "Source-to-Image framework and scripts" section above.
+
+##### 3.1. To use your own setup, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-118
+
+# Add application sources
+ADD test-app/nginx.conf "${NGINX_CONF_PATH}"
+ADD test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+ADD test-app/*.html .
+
+# Run script uses standard ways to run the application
+CMD nginx -g "daemon off;"
+```
+
+##### 3.2. To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
+
+```
+FROM registry.access.redhat.com/ubi8/nginx-118
+
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+USER 0
+ADD test-app /tmp/src/
+RUN chown -R 1001:0 /tmp/src
+USER 1001
+
+# Let the assemble script to install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Run script uses standard ways to run the application
+CMD /usr/libexec/s2i/run
+```
+
+#### 4. Build a new image from a Dockerfile prepared in the previous step
+```
+podman build -t nginx-app .
+```
+
+#### 5. Run the resulting image with the final application
+```
+podman run -d nginx-app
+```
+
+
+Direct usage with a mounted directory
+-------------------------------------
+An example of the data on the host for the following example:
+```
+$ ls -lZ /wwwdata/html
+-rw-r--r--. 1 1001 1001 54321 Jan 01 12:34 index.html
+-rw-r--r--. 1 1001 1001  5678 Jan 01 12:34 page.html
+```
+
+If you want to run the image directly and mount the static pages available in the `/wwwdata/` directory on the host
+as a container volume, execute the following command:
+
+```
+$ podman run -d --name nginx -p 8080:8080 -v /wwwdata:/opt/app-root/src:Z rhel8/nginx-118 nginx -g "daemon off;"
+```
+
+This creates a container named `nginx` running the Nginx server, serving data from
+the `/wwwdata/` directory. Port 8080 is exposed and mapped to the host.
+You can pull the data from the nginx container using this command:
+
+```
+$ curl -Lk 127.0.0.1:8080
+```
+
+You can replace `/wwwdata/` with location of your web root. Please note that this has to be an **absolute** path, due to podman requirements.
+
+
 Environment variables and volumes
 ---------------------------------
 The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
@@ -74,13 +183,6 @@ The nginx container image supports the following configuration variable, which c
 
 **`NGINX_LOG_TO_VOLUME`**
        When `NGINX_LOG_TO_VOLUME` is set, nginx logs into `/var/log/nginx/`. In case of RHEL-7 and CentOS-7 images, this is a symlink to `/var/opt/rh/rh-nginx118/log/nginx/`.
-
-
-You can mount your own web root like this:
-```
-$ podman run -v <DIR>:/var/www/html/ <container>
-```
-You can replace \<DIR> with location of your web root. Please note that this has to be an **absolute** path, due to podman requirements.
 
 
 Troubleshooting

--- a/1.18/s2i/bin/usage
+++ b/1.18/s2i/bin/usage
@@ -1,17 +1,19 @@
 #!/bin/sh
 
 DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
-NAMESPACE=centos
-[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
 
 cat <<EOF
-This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image:
-To use it, install S2I: https://github.com/openshift/source-to-image
+This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image.
 
-Sample invocation:
+To use it in OpenShift, run:
 
-s2i build https://github.com/sclorg/nginx-container.git --context-dir=${NGINX_VERSION}/test/test-app/ ${NAMESPACE}/nginx-${NGINX_SHORT_VER}-${DISTRO}7 nginx-sample-app
+  oc new-app nginx:${NGINX_VERSION}~https://github.com/sclorg/nginx-container.git --context-dir=${NGINX_VERSION}/test/test-app/
 
 You can then run the resulting image via:
-docker run -p 8080:8080 nginx-sample-app
+
+  docker run -p 8080:8080 nginx-sample-app
+
+Alternatively, to run the image directly using podman or docker, or how to use it as a parent image in a Dockerfile, see documentation at
+
+  https://github.com/sclorg/nginx-container/blob/master/${NGINX_VERSION}/README.md.
 EOF

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.access.redhat.com/ubi8/nginx-118
 ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx.conf "${NGINX_CONF_PATH}"
 ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
 ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
-ADD nginx-container/examples/$NGINX_VERSION/test-app/*.html .
+ADD nginx-container/examples/$NGINX_VERSION/test-app/*.html ./
 
 # Run script uses standard ways to run the application
 CMD nginx -g "daemon off;"

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,12 +1,10 @@
 FROM registry.access.redhat.com/ubi8/nginx-118
 
-ENV VERSION=1.18
-
 # Add application sources
-ADD $VERSION/test-app/nginx.conf "${NGINX_CONF_PATH}"
-ADD $VERSION/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
-ADD $VERSION/test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
-ADD $VERSION/test-app/*.html .
+ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx.conf "${NGINX_CONF_PATH}"
+ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+ADD nginx-container/examples/$NGINX_VERSION/test-app/*.html .
 
 # Run script uses standard ways to run the application
 CMD nginx -g "daemon off;"

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8/nginx-118
+
+ENV VERSION=1.18
+
+# Add application sources
+ADD $VERSION/test-app/nginx.conf "${NGINX_CONF_PATH}"
+ADD $VERSION/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"
+ADD $VERSION/test-app/nginx-cfg/*.conf "${NGINX_CONFIGURATION_PATH}"
+ADD $VERSION/test-app/*.html .
+
+# Run script uses standard ways to run the application
+CMD nginx -g "daemon off;"

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi8/nginx-118
 
+ENV NGINX_VERSION=1.18
+
 # Add application sources
 ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx.conf "${NGINX_CONF_PATH}"
 ADD nginx-container/examples/$NGINX_VERSION/test-app/nginx-default-cfg/*.conf "${NGINX_DEFAULT_CONF_PATH}"

--- a/examples/Dockerfile.s2i
+++ b/examples/Dockerfile.s2i
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi8/nginx-118
 
+ENV NGINX_VERSION=1.18
+
 # This image supports the Source-to-Image
 # (see more at https://docs.openshift.com/container-platform/3.11/creating_images/s2i.html).
 # In order to support the Source-to-Image framework, there are some interesting

--- a/examples/Dockerfile.s2i
+++ b/examples/Dockerfile.s2i
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi8/nginx-118
 
-ENV VERSION=1.18
-
 # This image supports the Source-to-Image
 # (see more at https://docs.openshift.com/container-platform/3.11/creating_images/s2i.html).
 # In order to support the Source-to-Image framework, there are some interesting
@@ -16,7 +14,7 @@ ENV VERSION=1.18
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
 USER 0
-ADD $VERSION/test-app /tmp/src/
+ADD nginx-container/examples/$NGINX_VERSION/test-app /tmp/src/
 RUN chown -R 1001:0 /tmp/src
 USER 1001
 

--- a/examples/Dockerfile.s2i
+++ b/examples/Dockerfile.s2i
@@ -1,0 +1,27 @@
+FROM registry.access.redhat.com/ubi8/nginx-118
+
+ENV VERSION=1.18
+
+# This image supports the Source-to-Image
+# (see more at https://docs.openshift.com/container-platform/3.11/creating_images/s2i.html).
+# In order to support the Source-to-Image framework, there are some interesting
+# scripts inside the builder image, that can be run in a Dockerfile directly as well:
+# * The `/usr/libexec/s2i/assemble` script inside the image is run in order
+#   to produce a new image with the application artifacts.
+#   The script takes sources of a given application and places them into
+#   appropriate directories inside the image.
+# * The `/usr/libexec/s2i/run` script executes the application and is set as
+#   a default command in the resulting container image.
+
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+USER 0
+ADD $VERSION/test-app /tmp/src/
+RUN chown -R 1001:0 /tmp/src
+USER 1001
+
+# Let the assemble script to install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Run script uses standard ways to run the application
+CMD /usr/libexec/s2i/run

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,30 +1,19 @@
-# `test-app`
-This is a simple example of static content served using nginx.
+# Test application for Nginx
 
-## Building with s2i
-### Version 1.8
-```
-s2i build https://github.com/sclorg/nginx-container.git --context-dir=examples/1.8/test-app/ centos/nginx-18-centos7 nginx-sample-app
-```
-### Version 1.10
-```
-s2i build https://github.com/sclorg/nginx-container.git --context-dir=examples/1.10/test-app/ centos/nginx-110-centos7 nginx-sample-app
-```
-### Version 1.12
-```
-s2i build https://github.com/sclorg/nginx-container.git --context-dir=examples/1.12/test-app/ centos/nginx-112-centos7 nginx-sample-app
-```
+This is a simple example of static content and configuration files served using nginx.
+
+## Building with s2i and Dockerfile
+
+See [the main documentation](/1.18/README.md) for steps how to use this image
+with a podman directly or in a Dockerfile, utilizing the source-to-image scripts.
 
 ## Building and deploying in OpenShift
-### Version 1.8
+
+### Version 1.16
 ```
-oc new-app centos/nginx-18-centos7~https://github.com/sclorg/nginx-container.git --context-dir=examples/1.8/test-app/
+oc new-app nginx:1.16~https://github.com/sclorg/nginx-container.git --context-dir=1.16/test/test-app/
 ```
-### Version 1.10
+### Version 1.18
 ```
-oc new-app centos/nginx-110-centos7~https://github.com/sclorg/nginx-container.git --context-dir=examples/1.10/test-app/
-```
-### Version 1.12
-```
-oc new-app centos/nginx-112-centos7~https://github.com/sclorg/nginx-container.git --context-dir=examples/1.12/test-app/
+oc new-app nginx:1.18~https://github.com/sclorg/nginx-container.git --context-dir=1.18/test/test-app/
 ```

--- a/test/run
+++ b/test/run
@@ -413,8 +413,11 @@ test_scl_enable() {
 }
 
 function run_dockerfiles_test() {
+  local dockerfile_tmp=$(mktemp)
+  sed -e "s/^ENV NGINX_VERSION/ENV NGINX_VERSION=$VERSION/" ../examples/Dockerfile >"$dockerfile_tmp"
   ct_test_app_dockerfile ../examples/Dockerfile 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
   check_result $? || return 1
+  sed -e "s/^ENV NGINX_VERSION/ENV NGINX_VERSION=$VERSION/" ../examples/Dockerfile >"$dockerfile_tmp"
   ct_test_app_dockerfile ../examples/Dockerfile.s2i 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
   check_result $? || return 1
 }

--- a/test/run
+++ b/test/run
@@ -412,6 +412,13 @@ test_scl_enable() {
   check_result $? || return 1
 }
 
+function run_dockerfiles_test() {
+  ct_test_app_dockerfile ../examples/Dockerfile 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
+  check_result $? || return 1
+  ct_test_app_dockerfile ../examples/Dockerfile.s2i 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
+  check_result $? || return 1
+}
+
 CID_FILE_DIR=$(mktemp -d)
 
 build_image "test-app"
@@ -429,14 +436,20 @@ build_image "perl-test-app"
 # Run the chosen tests
 TEST_LIST=${TEST_LIST_PERL_APP} run_all_tests "perl-test-app"
 
+# Run the rest of the tests by defining TEST_LIST to include the rest of the relevant cases
+TEST_LIST=run_dockerfiles_test
+
 # These tests only make sense for rhscl
 if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
   # autocleanup only enabled here as only the following tests so far use it
   ct_enable_cleanup
-
-  TEST_LIST=test_scl_enable run_all_tests
+  TEST_LIST="$TEST_LIST test_scl_enable"
 fi
 
+# Execute the rest of the tests depending on what TEST_LIST includes now
+run_all_tests
+
+# All tests executed, see the results
 echo "$test_short_summary"
 
 if [ $TESTSUITE_RESULT -eq 0 ] ; then


### PR DESCRIPTION
This PR depends on #128 that needs to be merged first.

This adds the following enhancements:

- Dockerfile examples for a variant that uses s2i scripts and a variant without s2i scripts
- Documentation enhancement that describes how the image can be used using a Dockerfile
- A test for the example Dockerfiles

This is a similar pull-request as sclorg/httpd-container#99., sclorg/s2i-nodejs-container#247 and sclorg/s2i-perl-container#192

To see the formatted README.md, see https://github.com/hhorak/nginx-container/blob/doc-dockerfile/1.18/README.md and it is also visible in the catalog, which will be the most important view: https://catalog.redhat.com/software/containers/detail/5f521a6f9dd2d5ca7158e5dc