### PR TITLE
Support registry Quay.io instead of Docker.io

### DIFF
--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos7/s2i-core-centos7:1
+FROM quay.io/centos7/s2i-core-centos7
 
 # RHSCL rh-nginx114 image.
 #

--- a/1.14/Dockerfile
+++ b/1.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7:1
+FROM quay.io/centos7/s2i-core-centos7:1
 
 # RHSCL rh-nginx114 image.
 #
@@ -28,11 +28,11 @@ LABEL summary="${SUMMARY}" \
       io.openshift.expose-services="8443:https" \
       io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
       com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
-      name="centos/${NAME}-${NGINX_SHORT_VER}-centos7" \
+      name="centos7/${NAME}-${NGINX_SHORT_VER}-centos7" \
       version="${NGINX_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/${NAME}-container" \
-      usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
+      usage="s2i build <SOURCE-REPOSITORY> centos7/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
 
 ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf \

--- a/1.14/README.md
+++ b/1.14/README.md
@@ -1,9 +1,9 @@
 Nginx 1.14 server and a reverse proxy server container image
-=========================================================
+============================================================
 This container image includes Nginx 1.14 server and a reverse server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -43,7 +43,7 @@ $ curl 127.0.0.1:8080
 
 
 S2I build support
--------------
+-----------------
 This image can be extended in Openshift using the `Source` build strategy or via the standalone
 [source-to-image](https://github.com/openshift/source-to-image) application (where available).
 S2I build folder structure:
@@ -68,7 +68,7 @@ S2I build folder structure:
 
 
 Environment variables and volumes
--------------
+---------------------------------
 The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
 
 

--- a/1.16/Dockerfile
+++ b/1.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7:1
+FROM quay.io/centos7/s2i-core-centos7:1
 
 # RHSCL rh-nginx116 image.
 #
@@ -28,11 +28,11 @@ LABEL summary="${SUMMARY}" \
       io.openshift.expose-services="8443:https" \
       io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
       com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
-      name="centos/${NAME}-${NGINX_SHORT_VER}-centos7" \
+      name="centos7/${NAME}-${NGINX_SHORT_VER}-centos7" \
       version="${NGINX_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/${NAME}-container" \
-      usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
+      usage="s2i build <SOURCE-REPOSITORY> centos7/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
 
 ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf \

--- a/1.16/Dockerfile
+++ b/1.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos7/s2i-core-centos7:1
+FROM quay.io/centos7/s2i-core-centos7
 
 # RHSCL rh-nginx116 image.
 #

--- a/1.16/README.md
+++ b/1.16/README.md
@@ -1,9 +1,9 @@
 Nginx 1.16 server and a reverse proxy server container image
-=========================================================
+============================================================
 This container image includes Nginx 1.16 server and a reverse server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -43,7 +43,7 @@ $ curl 127.0.0.1:8080
 
 
 S2I build support
--------------
+-----------------
 This image can be extended in Openshift using the `Source` build strategy or via the standalone
 [source-to-image](https://github.com/openshift/source-to-image) application (where available).
 S2I build folder structure:
@@ -68,7 +68,7 @@ S2I build folder structure:
 
 
 Environment variables and volumes
--------------
+---------------------------------
 The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
 
 

--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos7:1
+FROM quay.io/centos7/s2i-core-centos7:1
 
 # RHSCL rh-nginx118 image.
 #
@@ -28,11 +28,11 @@ LABEL summary="${SUMMARY}" \
       io.openshift.expose-services="8443:https" \
       io.openshift.tags="builder,${NAME},rh-${NAME}${NGINX_SHORT_VER}" \
       com.redhat.component="rh-${NAME}${NGINX_SHORT_VER}-container" \
-      name="centos/${NAME}-${NGINX_SHORT_VER}-centos7" \
+      name="centos7/${NAME}-${NGINX_SHORT_VER}-centos7" \
       version="${NGINX_VERSION}" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/${NAME}-container" \
-      usage="s2i build <SOURCE-REPOSITORY> centos/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
+      usage="s2i build <SOURCE-REPOSITORY> centos7/${NAME}-${NGINX_SHORT_VER}-centos7:latest <APP-NAME>"
 
 ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/opt/rh/rh-nginx${NGINX_SHORT_VER}/nginx/nginx.conf \

--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos7/s2i-core-centos7:1
+FROM quay.io/centos7/s2i-core-centos7
 
 # RHSCL rh-nginx118 image.
 #

--- a/1.18/README.md
+++ b/1.18/README.md
@@ -1,9 +1,9 @@
 Nginx 1.18 server and a reverse proxy server container image
-=========================================================
+============================================================
 This container image includes Nginx 1.18 server and a reverse server for OpenShift and general usage.
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
-the CentOS images are available on [Docker Hub](https://hub.docker.com/r/centos/),
+the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -43,7 +43,7 @@ $ curl 127.0.0.1:8080
 
 
 S2I build support
--------------
+-----------------
 This image can be extended in Openshift using the `Source` build strategy or via the standalone
 [source-to-image](https://github.com/openshift/source-to-image) application (where available).
 S2I build folder structure:
@@ -68,7 +68,7 @@ S2I build folder structure:
 
 
 Environment variables and volumes
--------------
+---------------------------------
 The nginx container image supports the following configuration variable, which can be set by using the `-e` option with the podman run command:
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 Nginx container images
-===================
+======================
+
+nginx-container 1.14 status: [![Docker Repository on Quay](https://quay.io/repository/centos7/nginx-114-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/nginx-114-centos7)
+
+nginx-container 1.16 status: [![Docker Repository on Quay](https://quay.io/repository/centos7/nginx-116-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/nginx-116-centos7)
+
+nginx-container 1.18 status: [![Docker Repository on Quay](https://quay.io/repository/centos7/nginx-118-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/nginx-118-centos7)
 
 This repository contains Dockerfiles for Nginx images for OpenShift.
 Users can choose between RHEL and CentOS based images.
@@ -11,7 +17,7 @@ For more information about concepts used in these container images, see the
 
 
 Versions
----------------
+--------
 Nginx versions currently provided are:
 * [nginx-1.14](1.14)
 * [nginx-1.16](1.16)
@@ -52,7 +58,7 @@ Choose either the CentOS7 or RHEL7 based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ podman pull centos/nginx-116-centos7
+    $ podman pull quay.io/centos7/nginx-116-centos7
     ```
 
     To build a CentOS based Nginx image from scratch, run:
@@ -75,7 +81,7 @@ This variable must be set to a list with possible versions (subdirectories).**
 
 
 Usage
----------------------------------
+-----
 
 For information about usage of Dockerfile for nginx 1.14,
 see [usage documentation](1.14).
@@ -84,7 +90,7 @@ For information about usage of Dockerfile for nginx 1.16,
 see [usage documentation](1.16).
 
 Build
----------------------------------
+-----
 Images can be built using `make` command.
 
 ```

--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -81,7 +81,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/nginx-116-centos7:latest"
+          "name": "quay.io/centos7/nginx-116-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -101,7 +101,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/nginx-116-centos7:latest"
+          "name": "quay.io/centos7/nginx-116-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Update README.md and Dockerfile

This commit updates README.md files and Dockerfile
which are used for building CentOS 7

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>