### PR TITLE
Use --chown option for ADD when adding app source instead of changing USER

### DIFF
--- a/1.16/README.md
+++ b/1.16/README.md
@@ -126,10 +126,13 @@ FROM registry.access.redhat.com/ubi8/nginx-116
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD test-app /tmp/src/
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 
 # Let the assemble script to install the dependencies
 RUN /usr/libexec/s2i/assemble

--- a/1.18/README.md
+++ b/1.18/README.md
@@ -126,10 +126,13 @@ FROM registry.access.redhat.com/ubi8/nginx-118
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD test-app /tmp/src/
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 
 # Let the assemble script to install the dependencies
 RUN /usr/libexec/s2i/assemble

--- a/examples/Dockerfile.s2i
+++ b/examples/Dockerfile.s2i
@@ -15,6 +15,9 @@ ENV NGINX_VERSION=1.18
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
+# With a newer docker that supports --chown option for ADD statement, or with
+# podman, we can replace the following four statements with
+#   ADD --chown 1001:0 <app-src> /tmp/src
 USER 0
 ADD nginx-container/examples/$NGINX_VERSION/test-app /tmp/src/
 RUN chown -R 1001:0 /tmp/src

--- a/test/run
+++ b/test/run
@@ -414,12 +414,13 @@ test_scl_enable() {
 
 function run_dockerfiles_test() {
   local dockerfile_tmp=$(mktemp)
-  sed -e "s/^ENV NGINX_VERSION/ENV NGINX_VERSION=$VERSION/" ../examples/Dockerfile >"$dockerfile_tmp"
-  ct_test_app_dockerfile ../examples/Dockerfile 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
+  sed -e "s/^ENV NGINX_VERSION.*$/ENV NGINX_VERSION=$VERSION/" -e "s/\$NGINX_VERSION/$VERSION/g" ../examples/Dockerfile >"$dockerfile_tmp"
+  ct_test_app_dockerfile "$dockerfile_tmp" 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
   check_result $? || return 1
-  sed -e "s/^ENV NGINX_VERSION/ENV NGINX_VERSION=$VERSION/" ../examples/Dockerfile >"$dockerfile_tmp"
-  ct_test_app_dockerfile ../examples/Dockerfile.s2i 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
+  sed -e "s/^ENV NGINX_VERSION.*$/ENV NGINX_VERSION=$VERSION/" -e "s/\$NGINX_VERSION/$VERSION/g" ../examples/Dockerfile >"$dockerfile_tmp"
+  ct_test_app_dockerfile "$dockerfile_tmp" 'https://github.com/sclorg/nginx-container.git' "NGINX is working" nginx-container
   check_result $? || return 1
+  rm "$dockerfile_tmp"
 }
 
 CID_FILE_DIR=$(mktemp -d)


### PR DESCRIPTION
I found this `--chown` option of `ADD` statement in the Dockerfile today, it seems like much better way to set correct permissions to make the assemble script work.