### PR TITLE
Revert "imagestreams: point 1.14 centos image to quay"

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -141,7 +141,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/centos7/nginx-114-centos8:latest"
+          "name": "docker.io/centos/nginx-114-centos8:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Reverts sclorg/nginx-container#143

Picked the wrong quay.io organization (`centos7`) for centos8 image.

https://quay.io/organization/centos8 is blank, so reverting to dockerhub.

@phracek PTAL