### PR TITLE
nginx-centos imagestream: fix 1.16 centos8 tag

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -81,7 +81,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/nginx-116-centos7:latest"
+          "name": "docker.io/centos/nginx-116-centos8:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
nginx 1.16 CentOS8 tag should refer to CentOS8 image