### PR TITLE
Remove 1.14-el8 imagestreams

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -127,26 +127,6 @@
           "type": "Local"
         },
         "name": "1.16"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14 (CentOS 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.14"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "docker.io/centos/nginx-114-centos8:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.14-el8"
       }
     ]
   }

--- a/imagestreams/nginx-rhel-aarch64.json
+++ b/imagestreams/nginx-rhel-aarch64.json
@@ -67,26 +67,6 @@
           "type": "Local"
         },
         "name": "1.16-el8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14 (RHEL 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.14"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhel8/nginx-114:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.14-el8"
       }
     ]
   }

--- a/imagestreams/nginx-rhel.json
+++ b/imagestreams/nginx-rhel.json
@@ -127,26 +127,6 @@
           "type": "Local"
         },
         "name": "1.16"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.14/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.14 (RHEL 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.14"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhel8/nginx-114:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.14-el8"
       }
     ]
   }


### PR DESCRIPTION
RHEL 8 nginx:1.14 is going out of support in May 2021.
