### PR TITLE
force nginx link creation

### DIFF
--- a/1.10/s2i/bin/run
+++ b/1.10/s2i/bin/run
@@ -9,8 +9,8 @@ source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
 process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
 
 if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
-    /bin/ln -s /dev/stdout ${NGINX_LOG_PATH}/access.log
-    /bin/ln -s /dev/stderr ${NGINX_LOG_PATH}/error.log
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
 fi
 
 exec nginx -g "daemon off;"

--- a/1.12/s2i/bin/run
+++ b/1.12/s2i/bin/run
@@ -9,8 +9,8 @@ source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
 process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
 
 if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
-    /bin/ln -s /dev/stdout ${NGINX_LOG_PATH}/access.log
-    /bin/ln -s /dev/stderr ${NGINX_LOG_PATH}/error.log
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
 fi
 
 exec nginx -g "daemon off;"

--- a/1.14/s2i/bin/run
+++ b/1.14/s2i/bin/run
@@ -9,8 +9,8 @@ source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
 process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
 
 if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
-    /bin/ln -s /dev/stdout ${NGINX_LOG_PATH}/access.log
-    /bin/ln -s /dev/stderr ${NGINX_LOG_PATH}/error.log
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
 fi
 
 exec nginx -g "daemon off;"

--- a/1.16/s2i/bin/run
+++ b/1.16/s2i/bin/run
@@ -9,8 +9,8 @@ source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
 process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
 
 if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
-    /bin/ln -s /dev/stdout ${NGINX_LOG_PATH}/access.log
-    /bin/ln -s /dev/stderr ${NGINX_LOG_PATH}/error.log
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
 fi
 
 exec nginx -g "daemon off;"

--- a/1.18/s2i/bin/run
+++ b/1.18/s2i/bin/run
@@ -9,8 +9,8 @@ source ${NGINX_CONTAINER_SCRIPTS_PATH}/common.sh
 process_extending_files ${NGINX_APP_ROOT}/src/nginx-start ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start
 
 if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
-    /bin/ln -s /dev/stdout ${NGINX_LOG_PATH}/access.log
-    /bin/ln -s /dev/stderr ${NGINX_LOG_PATH}/error.log
+    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
+    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
 fi
 
 exec nginx -g "daemon off;"


### PR DESCRIPTION
When using this image in a classic docker container, it crashes after the first restart because the `run` script tries to create a link  that already exists from the first start.
This pull request includes the force option that will overwrite the link if it already exists.

```
if [ ! -v NGINX_LOG_TO_VOLUME -a -v NGINX_LOG_PATH ]; then
    /bin/ln -sf /dev/stdout ${NGINX_LOG_PATH}/access.log
    /bin/ln -sf /dev/stderr ${NGINX_LOG_PATH}/error.log
fi
```