### PR TITLE
Update imagestreams for RHEL 8.5 and RHSCL 3.8

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,12 +21,52 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.18-ubi8"
+          "name": "1.20-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.20"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nginx-120:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.20-ubi8"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.20"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi7/nginx-118:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.20-ubi7"
       },
       {
         "annotations": {
@@ -67,66 +107,6 @@
           "type": "Local"
         },
         "name": "1.18-ubi7"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16 (CentOS 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "docker.io/centos/nginx-116-centos8:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16-el8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16 (CentOS 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/nginx-116-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16-el7"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx,hidden",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/nginx-116-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16"
       }
     ]
   }

--- a/imagestreams/nginx-rhel-aarch64.json
+++ b/imagestreams/nginx-rhel-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/nginx-rhel-aarch64.json
+++ b/imagestreams/nginx-rhel-aarch64.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,12 +21,32 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.18-ubi8"
+          "name": "1.20-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.20"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nginx-120:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.20-ubi8"
       },
       {
         "annotations": {
@@ -47,26 +67,6 @@
           "type": "Local"
         },
         "name": "1.18-ubi8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16 (RHEL 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhel8/nginx-116:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16-el8"
       }
     ]
   }

--- a/imagestreams/nginx-rhel.json
+++ b/imagestreams/nginx-rhel.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/nginx-rhel.json
+++ b/imagestreams/nginx-rhel.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,12 +21,52 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.18-ubi8"
+          "name": "1.20-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.20"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nginx-120:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.20-ubi8"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 7)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.20"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi7/nginx-120:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.20-ubi7"
       },
       {
         "annotations": {
@@ -67,66 +107,6 @@
           "type": "Local"
         },
         "name": "1.18-ubi7"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16 (RHEL 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhel8/nginx-116:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16-el8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16 (RHEL 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/nginx-116-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16-el7"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.16/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.16",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx,hidden",
-          "version": "1.16"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/nginx-116-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.16"
       }
     ]
   }


### PR DESCRIPTION
- Update imagestreams for RHEL 8.5 and RHSCL 3.8
- Use groupified apiVersion
