### PR TITLE
Use testing-farm-as-github-action for container-tests

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -80,7 +80,7 @@ jobs:
           git_url: ${{ steps.tf_values.outputs.TMT_REPO }}
           git_ref: ${{ steps.tf_values.outputs.BRANCH_NAME }}
           tmt_plan_regex: ${{ matrix.tmt_plan }}
-          pull_request_status_name: ${{ matrix.context }}
+          pull_request_status_name: "new ${{ matrix.context }}"
           variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ steps.pr_nr.outputs.PR_NR }};OS=${{ matrix.os_test }};TEST_NAME=test"
           secrets: "QUAY_USERNAME=${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }};QUAY_TOKEN=${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}"
           compose: ${{ matrix.compose }}

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -1,0 +1,88 @@
+name: container-tests at Testing Farm
+
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: Container tests on Testing Farm service
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tmt_plan: "fedora"
+            os_test: "fedora"
+            context: "Fedora"
+            compose: "CentOS-7"
+          - tmt_plan: "centos7"
+            os_test: "centos7"
+            context: "CentOS7"
+            compose: "CentOS-7"
+          - tmt_plan: "rhel7-docker"
+            os_test: "rhel7"
+            context: "RHEL7"
+            compose: "RHEL-7.9-Released"
+          - tmt_plan: "rhel8-docker"
+            os_test: "rhel8"
+            context: "RHEL8"
+            compose: "RHEL-8.3.1-Released"
+          - tmt_plan: "c9s"
+            os_test: "c9s"
+            context: "CentOS Stream 9"
+            compose: "CentOS-Stream-9"
+
+    if: |
+      github.event.issue.pull_request
+      && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    steps:
+      - name: Get pull request number
+        id: pr_nr
+        run: |
+          PR_URL="${{ github.event.comment.issue_url }}"
+          echo "::set-output name=PR_NR::${PR_URL##*/}"
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+
+      - name: SHA value
+        id: sha_value
+        run: |
+          echo "::set-output name=SHA::$(git rev-parse HEAD)"
+
+      - name: Setup Testing Farm values
+        id: tf_values
+        run: |
+          branch_name="master"
+          api_key="${{ secrets.TF_INTERNAL_API_KEY }}"
+          tmt_repo="https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+          if [ "${{ matrix.tmt_plan }}" == "fedora" ] || [ "${{ matrix.tmt_plan }}" == "centos7" ] || [ "${{ matrix.tmt_plan }}" == "c9s" ]; then
+            api_key="${{ secrets.TF_PUBLIC_API_KEY }}"
+            branch_name="main"
+            tmt_repo="https://github.com/sclorg/sclorg-testing-farm"
+          fi
+          echo "::set-output name=API_KEY::$api_key"
+          echo "::set-output name=BRANCH_NAME::$branch_name"
+          echo "::set-output name=TMT_REPO::$tmt_repo"
+        shell: bash
+
+      # https://github.com/sclorg/testing-farm-as-github-action
+      - name: Schedule tests on external Testing Farm by Testing-Farm-as-github-action
+        id: github_action
+        uses: sclorg/testing-farm-as-github-action@v1
+        with:
+          api_key: ${{ steps.tf_values.outputs.API_KEY }}
+          git_url: ${{ steps.tf_values.outputs.TMT_REPO }}
+          git_ref: ${{ steps.tf_values.outputs.BRANCH_NAME }}
+          tmt_plan_regex: ${{ matrix.tmt_plan }}
+          pull_request_status_name: ${{ matrix.context }}
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ steps.pr_nr.outputs.PR_NR }};OS=${{ matrix.os_test }};TEST_NAME=test"
+          secrets: "QUAY_USERNAME=${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }};QUAY_TOKEN=${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}"
+          compose: ${{ matrix.compose }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds support to tests driven by https://github.com/sclorg/testing-farm-as-github-action

As soon as tests are working well, then `docker-tests.yml` file will be removed.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>