### PR TITLE
run all openshift4 tests even if one fails

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -13,7 +13,12 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 source ${THISDIR}/test-lib-nginx.sh
 source ${THISDIR}/test-lib-remote-openshift.sh
 
-set -eo nounset
+TEST_LIST="\
+test_nginx_integration
+test_nginx_imagestream
+"
+
+set -u
 
 ct_os_set_ocp4
 
@@ -26,12 +31,7 @@ oc status || false "It looks like oc is not properly logged in."
 # For testing on OpenShift 4 we use internal registry
 export CT_EXTERNAL_REGISTRY=true
 
-test_nginx_integration "${IMAGE_NAME}"
-
-# Check the imagestream
-# test_nginx_imagestream
-
-OS_TESTSUITE_RESULT=0
-
+TEST_SUMMARY=''
+TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "openshift-remote-cluster"
 # vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-nginx.sh
+++ b/test/test-lib-nginx.sh
@@ -12,8 +12,7 @@ source ${THISDIR}/test-lib.sh
 source ${THISDIR}/test-lib-openshift.sh
 
 function test_nginx_integration() {
-  local image_name=$1
-  ct_os_test_s2i_app "${image_name}" \
+  ct_os_test_s2i_app "${IMAGE_NAME}" \
                      "https://github.com/sclorg/nginx-container.git" \
                      "examples/${VERSION}/test-app" \
                      "Test NGINX passed"


### PR DESCRIPTION
This PR also enables `test_nginx_imagestream`, which was disabled.