### PR TITLE
get PR number from github.event.issue.number variable

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -39,16 +39,10 @@ jobs:
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
-      - name: Get pull request number
-        id: pr_nr
-        run: |
-          PR_URL="${{ github.event.comment.issue_url }}"
-          echo "::set-output name=PR_NR::${PR_URL##*/}"
-
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          ref: "refs/pull/${{ steps.pr_nr.outputs.PR_NR }}/head"
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
 
       - name: Setup Testing Farm values
         id: tf_values
@@ -76,7 +70,7 @@ jobs:
           git_ref: ${{ steps.tf_values.outputs.BRANCH_NAME }}
           tmt_plan_regex: ${{ matrix.tmt_plan }}
           pull_request_status_name: ${{ matrix.context }}
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ steps.pr_nr.outputs.PR_NR }};OS=${{ matrix.os_test }};TEST_NAME=test"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os_test }};TEST_NAME=test"
           compose: ${{ matrix.compose }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub offers information about specific action in its embedded variables.

Pull request number can be from the `issue_comment` event gathered via this variable:
```
${{ github.event.issue.number }}
```

This change was tested on testing repository:
https://github.com/zmiklank/test_github_actions/pull/6
Pull request number was correctly gathered, as can be seen in this GitHub action:
https://github.com/zmiklank/test_github_actions/runs/5466813043?check_suite_focus=true