### PR TITLE
[WIP] Make tests work also for rootless containers

### DIFF
--- a/test/run
+++ b/test/run
@@ -43,8 +43,9 @@ container_exists() {
 }
 
 container_ip() {
-  local ip=$(docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file))
-  echo ${ip:-localhost}
+  # local ip=$(docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file))
+  # echo ${ip:-localhost}
+  echo localhost
 }
 
 test_port() {

--- a/test/run
+++ b/test/run
@@ -29,8 +29,6 @@ TEST_LIST_PERL_APP="test_perl_directive"
 
 . $test_dir/test-lib.sh
 
-# TODO: This should be part of the image metadata
-test_port=8080
 
 info() {
   echo -e "\n\e[1m[INFO] $@...\e[0m\n"
@@ -45,7 +43,13 @@ container_exists() {
 }
 
 container_ip() {
-  docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file)
+  local ip=$(docker inspect --format="{{ .NetworkSettings.IPAddress }}" $(cat $cid_file))
+  echo ${ip:-localhost}
+}
+
+test_port() {
+  local port=$(docker inspect --format '{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort }}' $(cat $cid_file))
+  echo ${port:-8080}
 }
 
 run_s2i_build() {
@@ -69,8 +73,8 @@ prepare() {
 
 run_test_application() {
   run_args=${CONTAINER_ARGS:-}
-  info "Running docker run --user=10001 ${run_args} -d --cidfile=${cid_file} ${IMAGE_NAME}-${1}"
-  docker run --user=10001 ${run_args} -d --cidfile=${cid_file} ${IMAGE_NAME}-${1}
+  info "Running docker run --user=10001 -P  ${run_args} -d --cidfile=${cid_file} ${IMAGE_NAME}-${1}"
+  docker run --user=10001 -P ${run_args} -d --cidfile=${cid_file} ${IMAGE_NAME}-${1}
 }
 
 cleanup_test_app() {
@@ -221,12 +225,12 @@ test_for_output() {
 
 test_connection() {
   cat $cid_file
-  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+  info "Testing the HTTP connection (http://$(container_ip):$(test_port))"
 
-  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
-     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
-     test_for_output "http://$(container_ip):${test_port}/aliased/index2.html" "NGINX2 is working"  &&
-     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+  if test_for_output "http://$(container_ip):$(test_port)/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):$(test_port)/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):$(test_port)/aliased/index2.html" "NGINX2 is working"  &&
+     test_for_output "http://$(container_ip):$(test_port)/nginx-cfg/default.conf" "404"; then
      return 0
   fi
 
@@ -235,11 +239,11 @@ test_connection() {
 
 test_connection_s2i() {
   cat $cid_file
-  info "Testing the HTTP connection (http://$(container_ip):${test_port})"
+  info "Testing the HTTP connection (http://$(container_ip):$(test_port))"
 
-  if test_for_output "http://$(container_ip):${test_port}/" "NGINX is working" &&
-     test_for_output "http://$(container_ip):${test_port}/" "NGINX2 is working" localhost2 &&
-     test_for_output "http://$(container_ip):${test_port}/nginx-cfg/default.conf" "404"; then
+  if test_for_output "http://$(container_ip):$(test_port)/" "NGINX is working" &&
+     test_for_output "http://$(container_ip):$(test_port)/" "NGINX2 is working" localhost2 &&
+     test_for_output "http://$(container_ip):$(test_port)/nginx-cfg/default.conf" "404"; then
      return 0
   fi
 
@@ -291,7 +295,7 @@ test_log_output() {
 
   info "Testing that GET / was logged as 200"
 
-  test_for_output "http://$(container_ip):${test_port}/" "NGINX is working"
+  test_for_output "http://$(container_ip):$(test_port)/" "NGINX is working"
   check_result $? || return 1
 
   test_logs '"GET / HTTP/1.1" 200' 'Test that GET / is logged as 200' stdout
@@ -299,7 +303,7 @@ test_log_output() {
 
   info "Testing that GET /nothing-at-all was logged as 404"
 
-  test_for_output "http://$(container_ip):${test_port}/nothing-at-all" "404"
+  test_for_output "http://$(container_ip):$(test_port)/nothing-at-all" "404"
   check_result $? || return 1
 
   test_logs '"GET /nothing-at-all HTTP/1.1" 404' 'Test that bad GET is logged as 404' stdout
@@ -323,7 +327,7 @@ test_log_volume_output() {
 
   info "Testing that GET / was logged as 200"
 
-  test_for_output "http://$(container_ip):${test_port}/" "NGINX is working"
+  test_for_output "http://$(container_ip):$(test_port)/" "NGINX is working"
   check_result $? || return 1
 
   test_logs '"GET / HTTP/1.1" 200' 'Test that GET / is logged as 200' /var/log/nginx/access.log
@@ -331,7 +335,7 @@ test_log_volume_output() {
 
   info "Testing that GET /nothing-at-all was logged as 404"
 
-  test_for_output "http://$(container_ip):${test_port}/nothing-at-all" "404"
+  test_for_output "http://$(container_ip):$(test_port)/nothing-at-all" "404"
   check_result $? || return 1
 
   test_logs '"GET /nothing-at-all HTTP/1.1" 404' 'Test that bad GET is logged as 404' /var/log/nginx/access.log
@@ -355,11 +359,11 @@ test_perl_directive() {
   local perl_version=$(docker exec $(cat ${cid_file}) /bin/bash -c "perl -e 'print \"$^V\"'" 2>&1)
 
   info "Testing perl_set directive sets header with perl version"
-  test_for_output "http://$(container_ip):${test_port}/" "X-Perl-Version: ${perl_version}"
+  test_for_output "http://$(container_ip):$(test_port)/" "X-Perl-Version: ${perl_version}"
   check_result $? || return 1
 
   info "Testing perl directive runs perl location handler"
-  test_for_output "http://$(container_ip):${test_port}/perl" "Perl location handler is working"
+  test_for_output "http://$(container_ip):$(test_port)/perl" "Perl location handler is working"
   check_result $? || return 1
 
   cleanup_test_app


### PR DESCRIPTION
- add -P to docker run when running container tests

Publish all exposed ports to random ports on the host interface.
Add function for getting actual mapped port, and do not use hardcoded
8080. Return 8080, only when port is not published (works in rootfull
configuration in one subnet).

- return "localhost" as an IP, if container itself does not have any IP
  assigned (when running in rootless state)

- known issues -> rootfull configuration seem to run only for localhost:published_port combination
- also needs support from container-common-scripts (WIP)

NOT INTENDED FOR MERGING YET.

<!-- issue-commentator = {"comment-id":"2194480882"} -->