### PR TITLE
Using OC_ERR variable for OC failures

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -20,13 +20,14 @@ test_nginx_imagestream
 
 trap ct_os_cleanup EXIT SIGINT
 
-ct_os_set_ocp4
+ct_os_set_ocp4 || exit $OC_ERR
 
-ct_os_check_compulsory_vars
-
-ct_os_check_login || exit 1
+ct_os_check_compulsory_vars || exit $OC_ERR
 
 ct_os_tag_image_for_cvp "nginx"
+
+ct_os_check_login || exit $OC_ERR
+
 
 set -u
 


### PR DESCRIPTION
This would need a support in container-common-scripts.