### PR TITLE
Fixes: #117 Call tagging image after OpenShift is logged in

### DIFF
--- a/1.18/test/test-lib-remote-openshift.sh
+++ b/1.18/test/test-lib-remote-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-remote-openshift.sh
+../../common/test-lib-remote-openshift.sh

--- a/1.20/test/test-lib-remote-openshift.sh
+++ b/1.20/test/test-lib-remote-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-remote-openshift.sh
+../../common/test-lib-remote-openshift.sh

--- a/1.22/test/test-lib-remote-openshift.sh
+++ b/1.22/test/test-lib-remote-openshift.sh
@@ -1,1 +1,1 @@
-../../test/test-lib-remote-openshift.sh
+../../common/test-lib-remote-openshift.sh

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -10,8 +10,8 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-source ${THISDIR}/test-lib-nginx.sh
-source ${THISDIR}/test-lib-remote-openshift.sh
+source "${THISDIR}/test-lib-nginx.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_nginx_integration
@@ -24,9 +24,9 @@ ct_os_set_ocp4
 
 ct_os_check_compulsory_vars
 
-ct_os_tag_image_for_cvp "nginx"
-
 ct_os_check_login || exit 1
+
+ct_os_tag_image_for_cvp "nginx"
 
 set -u
 


### PR DESCRIPTION
Symlinks points to test directory instead of `common`.

In dist-git, the links are broken

Closes: #117

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>