### PR TITLE
Use nss_wrapper-libs only to get rid of perl

### DIFF
--- a/1.22-micro/Dockerfile.fedora
+++ b/1.22-micro/Dockerfile.fedora
@@ -5,7 +5,7 @@ RUN mkdir -p /mnt/rootfs
 # ADD https://copr.fedorainfracloud.org/coprs/hhorak/nginx-micro/repo/fedora-34/hhorak-nginx-micro-fedora-34.repo /etc/yum.repos.d/hhorak-nginx-micro-fedora-34.repo
 #     INSTALL_PKGS="$MICRO_PKGS nginx-core findutils hostname nss_wrapper-libs envsubst bind-utils" && \
 RUN MICRO_PKGS="coreutils-single glibc-minimal-langpack" && \
-    INSTALL_PKGS="$MICRO_PKGS nginx-core findutils hostname nss_wrapper gettext bind-utils" && \
+    INSTALL_PKGS="$MICRO_PKGS nginx-core findutils hostname nss_wrapper-libs gettext bind-utils" && \
     dnf install --installroot /mnt/rootfs $INSTALL_PKGS --releasever 36 --setopt install_weak_deps=false --nodocs -y && \
     dnf -y --installroot /mnt/rootfs clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*


### PR DESCRIPTION
This is not possible in RHEL8 yet unfortunately, as there is no `nss_wrapper-libs` package available.