### PR TITLE
EOL imagestreams for Nginx 1.18.

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -87,46 +87,6 @@
           "type": "Local"
         },
         "name": "1.20-ubi7"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.18 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.18"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/nginx-118:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.18-ubi8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.18 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.18"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/nginx-118:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.18-ubi7"
       }
     ]
   }

--- a/imagestreams/nginx-rhel-aarch64.json
+++ b/imagestreams/nginx-rhel-aarch64.json
@@ -67,26 +67,6 @@
           "type": "Local"
         },
         "name": "1.20-ubi8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.18 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.18"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nginx-118:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.18-ubi8"
       }
     ]
   }

--- a/imagestreams/nginx-rhel.json
+++ b/imagestreams/nginx-rhel.json
@@ -87,46 +87,6 @@
           "type": "Local"
         },
         "name": "1.20-ubi7"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.18 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.18"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nginx-118:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.18-ubi8"
-      },
-      {
-        "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.18/README.md.",
-          "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.18 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
-          "supports": "nginx",
-          "tags": "builder,nginx",
-          "version": "1.18"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/nginx-118:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        },
-        "name": "1.18-ubi7"
       }
     ]
   }


### PR DESCRIPTION
Nginx will reach EOL in November 2022 for CentOS 7, RHEL7, and for RHEL8.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>