### PR TITLE
centos7: use hardcoded VERSION in COPY command in Dockerfile

### DIFF
--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -59,10 +59,10 @@ RUN yum install -y yum-utils gettext hostname && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
-COPY $NGINX_VERSION/s2i/bin/ $STI_SCRIPTS_PATH
+COPY 1.18/s2i/bin/ $STI_SCRIPTS_PATH
 
 # Copy extra files to the image.
-COPY $NGINX_VERSION/root/ /
+COPY 1.18/root/ /
 
 # In order to drop the root user, we have to make some directories world
 # writeable as OpenShift default security model is to run the container under

--- a/1.20/Dockerfile
+++ b/1.20/Dockerfile
@@ -59,10 +59,10 @@ RUN yum install -y yum-utils gettext hostname && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
-COPY $NGINX_VERSION/s2i/bin/ $STI_SCRIPTS_PATH
+COPY 1.20/s2i/bin/ $STI_SCRIPTS_PATH
 
 # Copy extra files to the image.
-COPY $NGINX_VERSION/root/ /
+COPY 1.20/root/ /
 
 # Changing ownership and user rights to support following use-cases:
 # 1) running container on OpenShift, whose default security model


### PR DESCRIPTION
If we leave $NGINX_VERSION there the command fails, because $NGINX_VERSION is substituted with "".
This is caused by docker->podman change.
This fix is only workaround.
Strange is, that when I print value of $NGINX_VERSION directly in the Dockerfile it is set correctly to either 1.20 or 1.18.
    
The reason of this issue in not a invalid build context, the behavior would be different then.
Unfortunately it seems that all other sclorg containers are affected by this too.