### PR TITLE
use sclorg-specific wrapper for tfaga

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -4,112 +4,24 @@ on:
       - created
 jobs:
   container-tests:
-    # This job only runs for '[test]' pull request comments by owner, member
     runs-on: ubuntu-20.04
-    name: "Container-tests: ${{ matrix.version }} - ${{ matrix.context }}"
+    name: "Container-tests: ${{ matrix.version }} - ${{ matrix.os_test }}"
     strategy:
       fail-fast: false
       matrix:
         version: [ "1.20", "1.22", "1.22-micro" ]
-        os_test: [ "fedora", "centos7", "rhel7", "rhel8", "rhel9", "c9s"]
-        include:
-          - tmt_plan: "fedora"
-            os_test: "fedora"
-            context: "Fedora"
-            compose: "Fedora-latest"
-            api_key: "TF_PUBLIC_API_KEY"
-            branch: "main"
-            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
-          - tmt_plan: "centos7"
-            os_test: "centos7"
-            context: "CentOS7"
-            compose: "CentOS-7"
-            api_key: "TF_PUBLIC_API_KEY"
-            branch: "main"
-            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
-          - tmt_plan: "rhel7-docker"
-            os_test: "rhel7"
-            context: "RHEL7"
-            compose: "RHEL-7-LatestUpdated"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "rhel8-docker"
-            os_test: "rhel8"
-            context: "RHEL8"
-            compose: "RHEL-8.6.0-Nightly"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "rhel9-docker"
-            os_test: "rhel9"
-            context: "RHEL9"
-            compose: "RHEL-9.1.0-Nightly"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "rhel9-unsubscribed-docker"
-            os_test: "rhel9"
-            context: "RHEL9 - Unsubscribed host"
-            compose: "RHEL-9.1.0-Nightly"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "c9s"
-            os_test: "c9s"
-            context: "CentOS Stream 9"
-            compose: "CentOS-Stream-9"
-            api_key: "TF_PUBLIC_API_KEY"
-            branch: "main"
-            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
+        os_test: [ "fedora", "centos7", "rhel7", "rhel8", "rhel9", "c9s", "rhel9-unsubscribed" ]
+        test_case: [ "container" ]
 
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+      - uses: sclorg/tfaga-wrapper@main
         with:
-          ref: "refs/pull/${{ github.event.issue.number }}/head"
-
-      - name: Prepare needed variables
-        shell: bash
-        id: vars
-        run: |
-          dockerfile="Dockerfile.${{ matrix.os_test }}"
-          if [[ ${{ matrix.os_test }} == "centos7" ]]; then
-            dockerfile="Dockerfile"
-          fi
-          echo "::set-output name=DOCKERFILE_NAME::${dockerfile}"
-
-      - name: Check ${{ matrix.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }} is present
-        id: check_dockerfile
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }}"
-
-      - name: Check .exclude-${{ matrix.os_test }} file presents
-        id: check_exclude_file
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/.exclude-${{ matrix.os_test }}"
-
-      # https://github.com/sclorg/testing-farm-as-github-action
-      - name: Schedule tests for ${{ matrix.version }} - ${{ matrix.context }}
-        id: github_action
-        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
-        uses: sclorg/testing-farm-as-github-action@v1
-        with:
-          api_key: ${{ secrets[matrix.api_key] }}
-          git_url: ${{ matrix.tmt_repo }}
-          git_ref: ${{ matrix.branch }}
-          tf_scope: ${{ matrix.tf_scope }}
-          tmt_plan_regex: ${{ matrix.tmt_plan }}
-          pull_request_status_name: "${{ matrix.context }} - ${{ matrix.version }}"
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ matrix.version }};OS=${{ matrix.os_test }};TEST_NAME=test"
-          compose: ${{ matrix.compose }}
+          os_test: ${{ matrix.os_test }}
+          version: ${{ matrix.version }}
+          test_case: ${{ matrix.test_case }}
+          public_api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          private_api_key: ${{ secrets.TF_INTERNAL_API_KEY }}

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -4,103 +4,29 @@ on:
       - created
 jobs:
   openshift-tests:
-    # This job only runs for '[test-all]' or '[test-openshift] pull request comments by owner, member
-    name: "OpenShift tests: ${{ matrix.version }} - ${{ matrix.context }}"
+    name: "OpenShift tests: ${{ matrix.version }} - ${{ matrix.os_test }}"
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         version: [ "1.20", "1.22", "1.22-micro" ]
-        os_test: [ "centos7", "rhel7", "rhel8", "rhel9"]
+        os_test: [ "centos7", "rhel7", "rhel8", "rhel9" ]
+        test_case: [ "openshift-4" ]
         include:
-          - tmt_plan: "centos7"
-            os_test: "centos7"
-            context: "CentOS7 - OpenShift 3"
-            api_key: "TF_PUBLIC_API_KEY"
-            branch: "main"
-            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
-            compose: "CentOS-7"
-            test_name: "test-openshift"
-          - tmt_plan: "rhel7-openshift-3"
-            os_test: "rhel7"
-            context: "RHEL7 - OpenShift 3"
-            compose: "RHEL-7-LatestUpdated"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            test_name: "test-openshift"
-            tf_scope: "private"
-          - tmt_plan: "rhel7-openshift-4"
-            os_test: "rhel7"
-            context: "RHEL7 - OpenShift 4"
-            compose: "RHEL-7-LatestUpdated"
-            test_name: "test-openshift-4"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "rhel8-openshift-4"
-            os_test: "rhel8"
-            context: "RHEL8 - OpenShift 4"
-            compose: "RHEL-8.6.0-Nightly"
-            test_name: "test-openshift-4"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
-          - tmt_plan: "rhel9-openshift-4"
-            os_test: "rhel9"
-            context: "RHEL9 - OpenShift 4"
-            compose: "RHEL-9.1.0-Nightly"
-            test_name: "test-openshift-4"
-            api_key: "TF_INTERNAL_API_KEY"
-            branch: "master"
-            tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
-            tf_scope: "private"
+          - os_test: "centos7"
+            test_case: "openshift-3"
+          - os_test: "rhel7"
+            test_case: "openshift-3"
 
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test-openshift]') || contains(github.event.comment.body, '[test-all]'))
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+      - uses: sclorg/tfaga-wrapper@main
         with:
-          ref: "refs/pull/${{ github.event.issue.number }}/head"
-
-      - name: Prepare needed variables
-        shell: bash
-        id: vars
-        run: |
-          dockerfile="Dockerfile.${{ matrix.os_test }}"
-          if [[ ${{ matrix.os_test }} == "centos7" ]]; then
-            dockerfile="Dockerfile"
-          fi
-          echo "::set-output name=DOCKERFILE_NAME::${dockerfile}"
-
-      - name: Check if ${{ matrix.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }} is present
-        id: check_dockerfile
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/${{ steps.vars.outputs.DOCKERFILE_NAME }}"
-
-      - name: Check .exclude-${{ matrix.os_test }} file presents
-        id: check_exclude_file
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "${{ matrix.version }}/.exclude-${{ matrix.os_test }}"
-
-      # https://github.com/sclorg/testing-farm-as-github-action
-      - name: Schedule tests for ${{ matrix.version }} - ${{ matrix.context }}
-        id: github_action
-        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
-        uses: sclorg/testing-farm-as-github-action@v1
-        with:
-          api_key: ${{ secrets[matrix.api_key] }}
-          git_url: ${{ matrix.tmt_repo }}
-          git_ref: ${{ matrix.branch }}
-          tf_scope: ${{ matrix.tf_scope }}
-          tmt_plan_regex: ${{ matrix.tmt_plan }}
-          pull_request_status_name: "${{ matrix.context }} - ${{ matrix.version }}"
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ matrix.version }};OS=${{ matrix.os_test }};TEST_NAME=${{ matrix.test_name }}"
-          compose: ${{ matrix.compose }}
+          os_test: ${{ matrix.os_test }}
+          version: ${{ matrix.version }}
+          test_case: ${{ matrix.test_case }}
+          public_api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          private_api_key: ${{ secrets.TF_INTERNAL_API_KEY }}


### PR DESCRIPTION
This PR proposes extracting duplicate code from the testing GitHub Actions in containers repositories and moving it to its own repository.
This new repository is not yet created and I would like to know what @phracek thinks about it before creating it.
The new repository would contain composite GitHub Action which will work as a wrapper around tfaga for sclorg use-cases.

This PR also shows what changes would need to be done in all of the container repositories in order to propagate this change.

It could seem like it would be better to have this new composite action in container-common-scripts repository. However, the composite action filename has to be `action.yml` and that is too non-descriptive to be included in the container-common-scripts repository.
We can try symlinks, but I personally haven't tried if that works.
Because of this I think better solution would be to create whole new repository as I stated above.

So, @phracek WDYT?

This PR is more like a discussion starter, not ready to be merged. Therefore I am creating it as a draft.