### PR TITLE
use SIGQUIT as a STOPSIGNAL in all images

### DIFF
--- a/1.18/Dockerfile
+++ b/1.18/Dockerfile
@@ -90,6 +90,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/opt/rh/rh-nginx118/root/usr/share/nginx/html"]

--- a/1.18/Dockerfile.fedora
+++ b/1.18/Dockerfile.fedora
@@ -78,6 +78,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf-fed.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.18/Dockerfile.rhel7
+++ b/1.18/Dockerfile.rhel7
@@ -102,6 +102,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf-rhscl.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/opt/rh/rh-nginx118/root/usr/share/nginx/html"]

--- a/1.18/Dockerfile.rhel8
+++ b/1.18/Dockerfile.rhel8
@@ -83,6 +83,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.20/Dockerfile
+++ b/1.20/Dockerfile
@@ -101,6 +101,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf-rhscl.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/opt/rh/rh-nginx120/root/usr/share/nginx/html"]

--- a/1.20/Dockerfile.c9s
+++ b/1.20/Dockerfile.c9s
@@ -84,6 +84,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.20/Dockerfile.fedora
+++ b/1.20/Dockerfile.fedora
@@ -89,6 +89,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.20/Dockerfile.rhel7
+++ b/1.20/Dockerfile.rhel7
@@ -102,6 +102,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf-rhscl.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/opt/rh/rh-nginx120/root/usr/share/nginx/html"]

--- a/1.20/Dockerfile.rhel8
+++ b/1.20/Dockerfile.rhel8
@@ -84,6 +84,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.20/Dockerfile.rhel9
+++ b/1.20/Dockerfile.rhel9
@@ -82,6 +82,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.22-micro/Dockerfile.c9s
+++ b/1.22-micro/Dockerfile.c9s
@@ -93,6 +93,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf-fed.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.22-micro/Dockerfile.fedora
+++ b/1.22-micro/Dockerfile.fedora
@@ -98,6 +98,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.22-micro/Dockerfile.rhel8
+++ b/1.22-micro/Dockerfile.rhel8
@@ -101,6 +101,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.22/Dockerfile.c9s
+++ b/1.22/Dockerfile.c9s
@@ -84,6 +84,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.22/Dockerfile.fedora
+++ b/1.22/Dockerfile.fedora
@@ -88,6 +88,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]

--- a/1.22/Dockerfile.rhel8
+++ b/1.22/Dockerfile.rhel8
@@ -83,6 +83,8 @@ RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
 
 USER 1001
 
+STOPSIGNAL SIGQUIT
+
 # Not using VOLUME statement since it's not working in OpenShift Online:
 # https://github.com/sclorg/httpd-container/issues/30
 # VOLUME ["/usr/share/nginx/html"]


### PR DESCRIPTION
Nginx upstream [1] uses SIGQUIT for graceful shutdown even in their container images [2].

We switch to SIGQUIT too, as current default SIGTERM immediately closes opened connections.

[1] http://nginx.org/en/docs/control.html
[2] https://github.com/nginxinc/docker-nginx/issues/377


Resolves: https://github.com/sclorg/nginx-container/issues/242