### PR TITLE
migrate from f35/f36 to f37 for fedora images, as f35,f36 are now EOL

### DIFF
--- a/1.20/Dockerfile.fedora
+++ b/1.20/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:35
+FROM quay.io/fedora/s2i-core:37
 
 # nginx 1.20 image.
 #

--- a/1.22-micro/Dockerfile.fedora
+++ b/1.22-micro/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36 AS build
+FROM registry.fedoraproject.org/fedora:37 AS build
 
 RUN mkdir -p /mnt/rootfs
 # this is an alternative build of some packages with even smaller footprint on RPM level

--- a/1.22/Dockerfile.fedora
+++ b/1.22/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:36
+FROM quay.io/fedora/s2i-core:37
 
 # nginx 1.22 image.
 #


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
