### PR TITLE
stop building usupported Fedora images + move nginx 1.24 Fedora image to f38 base

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,12 +19,6 @@ jobs:
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
             tag: "c9s"
             image_name: "nginx-120-c9s"
-          - dockerfile: "1.22/Dockerfile.fedora"
-            registry_namespace: "fedora"
-            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
-            tag: "fedora"
-            image_name: "nginx-122"
           - dockerfile: "1.22-micro/Dockerfile.c9s"
             registry_namespace: "sclorg"
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
@@ -37,12 +31,6 @@ jobs:
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             tag: "fedora"
             image_name: "nginx-124"
-          - dockerfile: "1.22-micro/Dockerfile.fedora"
-            registry_namespace: "fedora"
-            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
-            tag: "fedora"
-            image_name: "nginx-124-micro"
 
     steps:
       - name: Build and push to quay.io registry

--- a/1.24/Dockerfile.fedora
+++ b/1.24/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:37
+FROM quay.io/fedora/s2i-core:38
 
 # nginx 1.24 image.
 #


### PR DESCRIPTION
The "1.22/Dockerfile.fedora" and "1.22-micro/Dockerfile.fedora" has already their .exclude-files, so are not being tested. This PR disables their building and pushing to quay.io too.