### PR TITLE
Move openshift tests to test-lib-nginx.sh and use it in OpenShift 4 as well

### DIFF
--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -13,24 +13,9 @@ source ${THISDIR}/test-lib.sh
 source ${THISDIR}/test-lib-openshift.sh
 source ${THISDIR}/test-lib-nginx.sh
 
-# TODO: branch should be changed to master, once code in example app
-# stabilizes on with referencing latest version
-BRANCH_TO_TEST=master
-
 set -eo nounset
 
 trap ct_os_cleanup EXIT SIGINT
-
-test_latest_imagestreams() {
-  local result=1
-  # Switch to root directory of a container
-  echo "Testing the latest version in imagestreams"
-  pushd "${test_dir}/../.." >/dev/null || return 1
-  ct_check_latest_imagestreams
-  result=$?
-  popd >/dev/null || return 1
-  return $result
-}
 
 ct_os_check_compulsory_vars
 
@@ -38,18 +23,11 @@ ct_os_enable_print_logs
 
 ct_os_cluster_up
 
-# test local app
-ct_os_test_s2i_app ${IMAGE_NAME} "${THISDIR}/test-app" . 'Test NGINX passed'
+test_nginx_local_example
 
-# test remote example app
-ct_os_test_s2i_app ${IMAGE_NAME} "https://github.com/sclorg/nginx-ex.git#${BRANCH_TO_TEST}" . 'Welcome to your static nginx application on OpenShift'
+test_nginx_remote_example
 
-# test template from the example app
-ct_os_test_template_app ${IMAGE_NAME} \
-                        https://raw.githubusercontent.com/sclorg/nginx-ex/${BRANCH_TO_TEST}/openshift/templates/nginx.json \
-                        nginx \
-                        'Welcome to your static nginx application on OpenShift' \
-                        8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
+test_nginx_template_from_example_app
 
 # Check the imagestream
 test_nginx_imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -15,7 +15,11 @@ source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_nginx_integration
+test_nginx_local_example
+test_nginx_remote_example
+test_nginx_template_from_example_app
 test_nginx_imagestream
+test_latest_imagestreams
 "
 
 trap ct_os_cleanup EXIT SIGINT

--- a/test/test-lib-nginx.sh
+++ b/test/test-lib-nginx.sh
@@ -25,4 +25,42 @@ function test_nginx_imagestream() {
                               "examples/${VERSION}/test-app" \
                               "Test NGINX passed"
 }
+
+function test_nginx_local_example() {
+  # test local app
+  ct_os_test_s2i_app ${IMAGE_NAME} "${THISDIR}/test-app" . 'Test NGINX passed'
+}
+
+function test_nginx_remote_example() {
+  # TODO: branch should be changed to master, once code in example app
+  # stabilizes on with referencing latest version
+  BRANCH_TO_TEST=master
+  # test remote example app
+  ct_os_test_s2i_app "${IMAGE_NAME}" \
+                     "https://github.com/sclorg/nginx-ex.git#${BRANCH_TO_TEST}" \
+                     . \
+                     'Welcome to your static nginx application on OpenShift'
+}
+
+function test_nginx_template_from_example_app() {
+  BRANCH_TO_TEST=master
+  # test template from the example app
+  ct_os_test_template_app "${IMAGE_NAME}" \
+                          "https://raw.githubusercontent.com/sclorg/nginx-ex/${BRANCH_TO_TEST}/openshift/templates/nginx.json" \
+                          nginx \
+                          'Welcome to your static nginx application on OpenShift' \
+                          8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
+
+}
+function test_latest_imagestreams() {
+  local result=1
+  # Switch to root directory of a container
+  echo "Testing the latest version in imagestreams"
+  pushd "${THISDIR}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  return $result
+}
+
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
Move openshift tests to test-lib-nginx.sh and use it in OpenShift 4 as well
Call all functions as in OpenShift 3 as in OpenShift 4

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
