### PR TITLE
temporary commit for testing nginx with new tfaga

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -18,7 +18,7 @@ jobs:
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
-      - uses: sclorg/tfaga-wrapper@main
+      - uses: sclorg/tfaga-wrapper@typescript
         with:
           os_test: ${{ matrix.os_test }}
           version: ${{ matrix.version }}

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -23,7 +23,7 @@ jobs:
       && (contains(github.event.comment.body, '[test-openshift]') || contains(github.event.comment.body, '[test-all]'))
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
-      - uses: sclorg/tfaga-wrapper@main
+      - uses: sclorg/tfaga-wrapper@typescript
         with:
           os_test: ${{ matrix.os_test }}
           version: ${{ matrix.version }}


### PR DESCRIPTION
Tfaga-wrapper provides new typescript-written tfaga in 'typescript' branch. This commit moves testing to this new tfaga.

Depends on: https://github.com/sclorg/testing-farm-as-github-action/pull/84

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
