### PR TITLE
This PR migrates DeploymentConfig to Deployment.

### DIFF
--- a/1.22/test/run-openshift-remote-cluster
+++ b/1.22/test/run-openshift-remote-cluster
@@ -15,7 +15,11 @@ source "${THISDIR}/test-lib-remote-openshift.sh"
 
 TEST_LIST="\
 test_nginx_integration
+test_nginx_local_example
+test_nginx_remote_example
+test_nginx_template_from_example_app
 test_nginx_imagestream
+test_latest_imagestreams
 "
 
 trap ct_os_cleanup EXIT SIGINT

--- a/1.22/test/test-lib-nginx.sh
+++ b/1.22/test/test-lib-nginx.sh
@@ -12,6 +12,9 @@ source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-openshift.sh"
 
 function test_nginx_integration() {
+  if [[ "${VERSION}" == *"micro"* ]]; then
+    VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
+  fi
   ct_os_test_s2i_app "${IMAGE_NAME}" \
                      "https://github.com/sclorg/nginx-container.git" \
                      "examples/${VERSION}/test-app" \
@@ -46,7 +49,7 @@ function test_nginx_template_from_example_app() {
   BRANCH_TO_TEST="master"
   # test template from the example app
   ct_os_test_template_app "${IMAGE_NAME}" \
-                          "https://raw.githubusercontent.com/phracek/nginx-ex/${BRANCH_TO_TEST}/openshift/templates/nginx.json" \
+                          "https://raw.githubusercontent.com/sclorg/nginx-ex/${BRANCH_TO_TEST}/openshift/templates/nginx.json" \
                           nginx \
                           'Welcome to your static nginx application on OpenShift' \
                           8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
@@ -55,6 +58,10 @@ function test_nginx_template_from_example_app() {
 
 function test_latest_imagestreams() {
   local result=1
+  if [[ "${VERSION}" == *"micro"* ]]; then
+    echo "Do not check 'micro' imagestreams. Only main versions."
+    return 0
+  fi
   # Switch to root directory of a container
   echo "Testing the latest version in imagestreams"
   pushd "${THISDIR}/../.." >/dev/null || return 1

--- a/1.22/test/test-lib-nginx.sh
+++ b/1.22/test/test-lib-nginx.sh
@@ -25,4 +25,42 @@ function test_nginx_imagestream() {
                               "examples/${VERSION}/test-app" \
                               "Test NGINX passed"
 }
+
+function test_nginx_local_example() {
+  # test local app
+  ct_os_test_s2i_app ${IMAGE_NAME} "${THISDIR}/test-app" . 'Test NGINX passed'
+}
+
+function test_nginx_remote_example() {
+  # TODO: branch should be changed to master, once code in example app
+  # stabilizes on with referencing latest version
+  BRANCH_TO_TEST="master"
+  # test remote example app
+  ct_os_test_s2i_app "${IMAGE_NAME}" \
+                     "https://github.com/sclorg/nginx-ex.git" \
+                     . \
+                     'Welcome to your static nginx application on OpenShift'
+}
+
+function test_nginx_template_from_example_app() {
+  BRANCH_TO_TEST="master"
+  # test template from the example app
+  ct_os_test_template_app "${IMAGE_NAME}" \
+                          "https://raw.githubusercontent.com/phracek/nginx-ex/${BRANCH_TO_TEST}/openshift/templates/nginx.json" \
+                          nginx \
+                          'Welcome to your static nginx application on OpenShift' \
+                          8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
+
+}
+
+function test_latest_imagestreams() {
+  local result=1
+  # Switch to root directory of a container
+  echo "Testing the latest version in imagestreams"
+  pushd "${THISDIR}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  return $result
+}
 # vim: set tabstop=2:shiftwidth=2:expandtab:

--- a/test/test-lib-nginx.sh
+++ b/test/test-lib-nginx.sh
@@ -52,6 +52,7 @@ function test_nginx_template_from_example_app() {
                           8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NGINX_VERSION=${VERSION} -p NAME=nginx-testing"
 
 }
+
 function test_latest_imagestreams() {
   local result=1
   # Switch to root directory of a container


### PR DESCRIPTION
This PR migrates DeploymentConfig to Deployment.

See more info here:
https://docs.openshift.com/container-platform/4.12/applications/deployments/what-deployments-are.html

Since OPenShift 4.14 DeploymentConfigs are deprecated: https://access.redhat.com/articles/7041372

See example PR here: https://github.com/sclorg/nginx-ex/pull/31
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
