### PR TITLE
Add nginx 1.22 to imagestreams and remove ubi8/1.20

### DIFF
--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -81,7 +81,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/nginx-120:latest"
+          "name": "registry.access.redhat.com/ubi8/nginx-122:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -61,7 +61,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi9/nginx-120:latest"
+          "name": "registry.access.redhat.com/ubi9/nginx-122:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,7 +21,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.20-ubi8"
+          "name": "1.22-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
@@ -50,14 +50,34 @@
       },
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
           "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 8)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
           "supports": "nginx",
           "tags": "builder,nginx",
-          "version": "1.20"
+          "version": "1.22"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/nginx-120:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.22-ubi9"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.22"
         },
         "from": {
           "kind": "DockerImage",
@@ -66,7 +86,7 @@
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "1.20-ubi8"
+        "name": "1.22-ubi8"
       },
       {
         "annotations": {

--- a/imagestreams/nginx-rhel-aarch64.json
+++ b/imagestreams/nginx-rhel-aarch64.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,7 +21,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.20-ubi8"
+          "name": "1.22-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
@@ -50,23 +50,43 @@
       },
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
           "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 8)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
           "supports": "nginx",
           "tags": "builder,nginx",
-          "version": "1.20"
+          "version": "1.22"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nginx-120:latest"
+          "name": "registry.redhat.io/ubi9/nginx-122:latest"
         },
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "1.20-ubi8"
+        "name": "1.22-ubi9"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.22"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nginx-122:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.22-ubi8"
       }
     ]
   }

--- a/imagestreams/nginx-rhel.json
+++ b/imagestreams/nginx-rhel.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Nginx available on OpenShift, including major version updates.",
           "iconClass": "icon-nginx",
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,7 +21,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.20-ubi8"
+          "name": "1.22-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
@@ -50,23 +50,43 @@
       },
       {
         "annotations": {
-          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
           "iconClass": "icon-nginx",
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 8)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
           "supports": "nginx",
           "tags": "builder,nginx",
-          "version": "1.20"
+          "version": "1.22"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nginx-120:latest"
+          "name": "registry.redhat.io/ubi9/nginx-122:latest"
         },
         "referencePolicy": {
           "type": "Local"
         },
-        "name": "1.20-ubi8"
+        "name": "1.22-ubi9"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Nginx HTTP server and a reverse proxy (nginx) on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
+          "iconClass": "icon-nginx",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/nginx-ex.git",
+          "supports": "nginx",
+          "tags": "builder,nginx",
+          "version": "1.22"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nginx-122:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "1.22-ubi8"
       },
       {
         "annotations": {


### PR DESCRIPTION
Nginx 1.20 went EOL in November 2023: https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle and 1.22 was missing.

@yselkowitz FYI if you don't mind looking at the changes
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
