### PR TITLE
${{ github.head_ref }} not available for issue comment trigger

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -4,7 +4,7 @@ on:
       - created
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: container_tests-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -4,7 +4,7 @@ on:
       - created
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ocp_tests-${{ github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We can use group based on issue number - so that on every PR only one parallel tests for containers and ocp could run.

Using ${{ github.head_ref }} is not valid for our use-case, see https://github.com/sclorg/nginx-container/actions/runs/8158453585

@jamacku PTAL.