### PR TITLE
Add testing NginX 1.24 container on OpenShift 4

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "1.20", "1.22", "1.22-micro" ]
+        version: [ "1.20", "1.22", "1.22-micro", "1.24" ]
         os_test: [ "rhel7", "rhel8", "rhel9" ]
         test_case: [ "openshift-4" ]
 


### PR DESCRIPTION
This pull request adds testing nginx 1.24 container on OpenShift 4.

Container tests are already tested.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
