### PR TITLE
Add support for testing Nginx 1.26 as container as openshift

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "1.20", "1.22", "1.22-micro", "1.24" ]
+        version: [ "1.20", "1.22", "1.22-micro", "1.24", "1.26" ]
         os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c9s", "rhel9-unsubscribed" ]
         test_case: [ "container" ]
 

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "1.20", "1.22", "1.22-micro", "1.24" ]
+        version: [ "1.20", "1.22", "1.22-micro", "1.24", "1.26" ]
         os_test: [ "rhel7", "rhel8", "rhel9" ]
         test_case: [ "openshift-4" ]
     steps:


### PR DESCRIPTION
Running tests is not needed. It only adds support into GitHub Action

This pull request blocks https://github.com/sclorg/nginx-container/pull/297
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
