### PR TITLE
deprecate c8s images, as EOL for c8s is 31th of May 2024

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,14 +38,6 @@ jobs:
             image_name: "nginx-124"
 
           - version: "1.24"
-            tag: "c8s"
-            dockerfile: "Dockerfile.c8s"
-            registry_namespace: "sclorg"
-            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
-            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
-            image_name: "nginx-124-c8s"
-
-          - version: "1.24"
             tag: "c9s"
             dockerfile: "Dockerfile.c9s"
             registry_namespace: "sclorg"

--- a/1.22-micro/README.md
+++ b/1.22-micro/README.md
@@ -195,6 +195,6 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/nginx-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for CentOS Stream 8 is called `Dockerfile.c8s`,
+for RHEL8 it's `Dockerfile.rhel8`,
 Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s` and the Fedora Dockerfile is called `Dockerfile.fedora`.
 

--- a/1.24/README.md
+++ b/1.24/README.md
@@ -199,6 +199,5 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/nginx-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for CentOS Stream 8 is called `Dockerfile.c8s`,
-Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s` and the Fedora Dockerfile is called `Dockerfile.fedora`.
+for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`, and the Fedora Dockerfile is called `Dockerfile.fedora`.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@ Nginx container images
 
 Images available on Quay are:
 * CentOS 7 [nginx-1.20](https://quay.io/repository/centos7/nginx-120-centos7)
-* CentOS Stream 8 [nginx-1.20](https://quay.io/repository/sclorg/nginx-120-c8s)
 * CentOS Stream 9 [nginx-1.20](https://quay.io/repository/sclorg/nginx-120-c9s)
 * Fedora [nginx-1.20](https://quay.io/repository/fedora/nginx-120)
 * Fedora [nginx-1.22](https://quay.io/repository/fedora/nginx-122)
 * Fedora [nginx-1.24](https://quay.io/repository/fedora/nginx-124)
-* Micro CentOS Stream 8 [nginx-1.22](https://quay.io/repository/sclorg/nginx-122-micro-c8s)
 * Micro CentOS Stream 9 [nginx-1.22](https://quay.io/repository/sclorg/nginx-122-micro-c9s)
 * Micro Fedora [nginx-1.22](https://quay.io/repository/fedora/nginx-122-micro)
 
@@ -39,7 +37,6 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS7
-* CentOS Stream 8
 * CentOS Stream 9
 
 


### PR DESCRIPTION
Wait until 31th of May for merge.
