### PR TITLE
Add 1.26 examples directory

### DIFF
--- a/examples/1.26/test-app/index.html
+++ b/examples/1.26/test-app/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX is working</h1>
+</body>
+</html>

--- a/examples/1.26/test-app/index2.html
+++ b/examples/1.26/test-app/index2.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+	<title>Test NGINX passed</title>
+</head>
+<body>
+<h1>NGINX2 is working</h1>
+</body>
+</html>

--- a/examples/1.26/test-app/nginx-cfg/default.conf
+++ b/examples/1.26/test-app/nginx-cfg/default.conf
@@ -1,0 +1,6 @@
+server {
+	listen       8080;
+	server_name  localhost2;
+	root         /opt/app-root/src;
+	index        index2.html;
+}

--- a/examples/1.26/test-app/nginx-default-cfg/alias.conf
+++ b/examples/1.26/test-app/nginx-default-cfg/alias.conf
@@ -1,0 +1,3 @@
+location /aliased/ {
+         alias /opt/app-root/src/;
+}

--- a/examples/1.26/test-app/nginx.conf
+++ b/examples/1.26/test-app/nginx.conf
@@ -1,0 +1,93 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # perl_modules /opt/app-root/etc/perl;
+    # perl_require Version.pm;
+    # perl_set $perl_version Version::installed;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include /opt/app-root/etc/nginx.default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+
+# Settings for a TLS enabled server.
+#
+#    server {
+#        listen       443 ssl http2 default_server;
+#        listen       [::]:443 ssl http2 default_server;
+#        server_name  _;
+#        root         /opt/app-root/src;
+#
+#        ssl_certificate "/etc/pki/nginx/server.crt";
+#        ssl_certificate_key "/etc/pki/nginx/private/server.key";
+#        ssl_session_cache shared:SSL:1m;
+#        ssl_session_timeout  10m;
+#        ssl_ciphers PROFILE=SYSTEM;
+#        ssl_prefer_server_ciphers on;
+#
+#        # Load configuration files for the default server block.
+#        include /opt/app-root/etc/nginx.default.d/*.conf;
+#
+#        location / {
+#        }
+#
+#        error_page 404 /404.html;
+#            location = /40x.html {
+#        }
+#
+#        error_page 500 502 503 504 /50x.html;
+#            location = /50x.html {
+#        }
+#    }
+
+}
+


### PR DESCRIPTION
This is needed for passing tests https://github.com/sclorg/nginx-container/pull/297

We have a test run_dockerfiles_test that clones upstream repository and adds examples/<version> application.
But in case of new version it does not exist yet ;)

This pull request avoids failing tests.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
