### PR TITLE
Fix helm charts order

### DIFF
--- a/1.20/test/test_helm_nginx_imagestreams.py
+++ b/1.20/test/test_helm_nginx_imagestreams.py
@@ -1,1 +1,0 @@
-../../test/test_helm_nginx_imagestreams.py

--- a/1.20/test/test_helm_nginx_template.py
+++ b/1.20/test/test_helm_nginx_template.py
@@ -1,1 +1,0 @@
-../../test/test_helm_nginx_template.py

--- a/1.20/test/test_shared_helm_nginx_imagestreams.py
+++ b/1.20/test/test_shared_helm_nginx_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_imagestreams.py

--- a/1.20/test/test_shared_helm_nginx_template.py
+++ b/1.20/test/test_shared_helm_nginx_template.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_template.py

--- a/1.22/test/test_helm_nginx_imagestreams.py
+++ b/1.22/test/test_helm_nginx_imagestreams.py
@@ -1,1 +1,0 @@
-../../test/test_helm_nginx_imagestreams.py

--- a/1.22/test/test_helm_nginx_template.py
+++ b/1.22/test/test_helm_nginx_template.py
@@ -1,1 +1,0 @@
-../../test/test_helm_nginx_template.py

--- a/1.22/test/test_shared_helm_nginx_imagestreams.py
+++ b/1.22/test/test_shared_helm_nginx_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_imagestreams.py

--- a/1.22/test/test_shared_helm_nginx_template.py
+++ b/1.22/test/test_shared_helm_nginx_template.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_template.py

--- a/1.24/test/test_helm_nginx_imagestreams.py
+++ b/1.24/test/test_helm_nginx_imagestreams.py
@@ -1,1 +1,0 @@
-../../test/test_helm_nginx_imagestreams.py

--- a/1.24/test/test_helm_nginx_template.py
+++ b/1.24/test/test_helm_nginx_template.py
@@ -1,1 +1,0 @@
-../../test/test_helm_nginx_template.py

--- a/1.24/test/test_shared_helm_nginx_imagestreams.py
+++ b/1.24/test/test_shared_helm_nginx_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_imagestreams.py

--- a/1.24/test/test_shared_helm_nginx_template.py
+++ b/1.24/test/test_shared_helm_nginx_template.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_template.py

--- a/1.26/test/test_nginx_imagestream_s2i.py
+++ b/1.26/test/test_nginx_imagestream_s2i.py
@@ -1,0 +1,1 @@
+../../test/test_nginx_imagestream_s2i.py

--- a/1.26/test/test_nginx_imagestreams.py
+++ b/1.26/test/test_nginx_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_nginx_imagestreams.py

--- a/1.26/test/test_nginx_local_example.py
+++ b/1.26/test/test_nginx_local_example.py
@@ -1,0 +1,1 @@
+../../test/test_nginx_local_example.py

--- a/1.26/test/test_nginx_remote_example.py
+++ b/1.26/test/test_nginx_remote_example.py
@@ -1,0 +1,1 @@
+../../test/test_nginx_remote_example.py

--- a/1.26/test/test_nginx_template_example_app.py
+++ b/1.26/test/test_nginx_template_example_app.py
@@ -1,0 +1,1 @@
+../../test/test_nginx_template_example_app.py

--- a/1.26/test/test_shared_helm_nginx_imagestreams.py
+++ b/1.26/test/test_shared_helm_nginx_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_imagestreams.py

--- a/1.26/test/test_shared_helm_nginx_template.py
+++ b/1.26/test/test_shared_helm_nginx_template.py
@@ -1,0 +1,1 @@
+../../test/test_shared_helm_nginx_template.py

--- a/test/test_shared_helm_nginx_imagestreams.py
+++ b/test/test_shared_helm_nginx_imagestreams.py
@@ -20,7 +20,7 @@ class TestHelmRHELNginxImageStreams:
     def setup_method(self):
         package_name = "nginx-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_shared_helm_nginx_template.py
+++ b/test/test_shared_helm_nginx_template.py
@@ -31,7 +31,7 @@ class TestHelmNginxTemplate:
     def setup_method(self):
         package_name = "nginx-template"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"


### PR DESCRIPTION
This pull request does not modify source neither tests. Only change order of test execution.

Container-ci-suite do no support switching between clusters.


<!-- issue-commentator = {"comment-id":"2459527380"} -->



















































































































































<!-- testing-farm = {"lock":"false","comment-id":"2459616163","data":[{"id":"e44f0d23-4c89-4f3b-8925-f2264b4fa926","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":317.639878,"created":"2024-11-06T12:19:36.467841","updated":"2024-11-06T12:19:36.467847","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e44f0d23-4c89-4f3b-8925-f2264b4fa926\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e44f0d23-4c89-4f3b-8925-f2264b4fa926/pipeline.log\">pipeline</a>"]},{"id":"985282ff-b8db-490a-8eeb-b688bc4074a5","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":361.562634,"created":"2024-11-06T12:19:44.517834","updated":"2024-11-06T12:19:44.517839","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/985282ff-b8db-490a-8eeb-b688bc4074a5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/985282ff-b8db-490a-8eeb-b688bc4074a5/pipeline.log\">pipeline</a>"]},{"id":"a31b9989-c071-4f13-99fb-f160c1490d88","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":414.652925,"created":"2024-11-06T12:19:52.502832","updated":"2024-11-06T12:19:52.502840","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a31b9989-c071-4f13-99fb-f160c1490d88\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a31b9989-c071-4f13-99fb-f160c1490d88/pipeline.log\">pipeline</a>"]},{"id":"2eaf8b90-6dbd-44b9-9274-8e8ed363c67f","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":557.63809,"created":"2024-11-06T12:19:50.326759","updated":"2024-11-06T12:19:50.326766","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2eaf8b90-6dbd-44b9-9274-8e8ed363c67f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2eaf8b90-6dbd-44b9-9274-8e8ed363c67f/pipeline.log\">pipeline</a>"]},{"id":"2cdb524b-b43b-4906-b6d3-d08768d14fb0","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":690.533318,"created":"2024-11-06T12:19:32.695272","updated":"2024-11-06T12:19:32.695278","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2cdb524b-b43b-4906-b6d3-d08768d14fb0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2cdb524b-b43b-4906-b6d3-d08768d14fb0/pipeline.log\">pipeline</a>"]},{"id":"b070effd-1bbb-419a-b1f2-fd76463344b3","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":698.428246,"created":"2024-11-06T12:19:35.830383","updated":"2024-11-06T12:19:35.830390","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b070effd-1bbb-419a-b1f2-fd76463344b3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b070effd-1bbb-419a-b1f2-fd76463344b3/pipeline.log\">pipeline</a>"]},{"id":"caf29225-8c18-4076-b6ce-aa3dfbd85d3f","name":"RHEL9 - Unsubscribed host - 1.24","status":"complete","outcome":"passed","runTime":707.993224,"created":"2024-11-06T12:19:48.138747","updated":"2024-11-06T12:19:48.138753","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/caf29225-8c18-4076-b6ce-aa3dfbd85d3f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/caf29225-8c18-4076-b6ce-aa3dfbd85d3f/pipeline.log\">pipeline</a>"]},{"id":"d2ba66f8-6117-4e27-a10e-f8085d9279d7","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":808.387551,"created":"2024-11-06T12:19:33.876090","updated":"2024-11-06T12:19:33.876096","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d2ba66f8-6117-4e27-a10e-f8085d9279d7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d2ba66f8-6117-4e27-a10e-f8085d9279d7/pipeline.log\">pipeline</a>"]},{"id":"7290eade-6d80-411c-84a8-99af8fb43acb","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":800.598201,"created":"2024-11-06T12:19:43.479252","updated":"2024-11-06T12:19:43.479260","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7290eade-6d80-411c-84a8-99af8fb43acb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7290eade-6d80-411c-84a8-99af8fb43acb/pipeline.log\">pipeline</a>"]},{"id":"2d1d21b1-3363-4977-9cf5-28a1cefc05ae","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":943.003473,"created":"2024-11-06T12:19:33.485763","updated":"2024-11-06T12:19:33.485769","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d1d21b1-3363-4977-9cf5-28a1cefc05ae\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d1d21b1-3363-4977-9cf5-28a1cefc05ae/pipeline.log\">pipeline</a>"]},{"id":"87244b9b-c1f2-475c-9528-02046eb6c1d2","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":987.301982,"created":"2024-11-06T12:19:42.146650","updated":"2024-11-06T12:19:42.146656","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87244b9b-c1f2-475c-9528-02046eb6c1d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87244b9b-c1f2-475c-9528-02046eb6c1d2/pipeline.log\">pipeline</a>"]},{"id":"c9f7be82-c4ec-4dfe-9877-8f1eabebcbcb","name":"RHEL9 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":987.299273,"created":"2024-11-06T12:20:03.553323","updated":"2024-11-06T12:20:03.553329","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9f7be82-c4ec-4dfe-9877-8f1eabebcbcb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9f7be82-c4ec-4dfe-9877-8f1eabebcbcb/pipeline.log\">pipeline</a>"]},{"id":"eb1574ce-1ce4-41b1-a2da-5f30c3b1d214","name":"RHEL9 - PyTest - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":998.422923,"created":"2024-11-06T12:19:55.415635","updated":"2024-11-06T12:19:55.415641","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb1574ce-1ce4-41b1-a2da-5f30c3b1d214\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb1574ce-1ce4-41b1-a2da-5f30c3b1d214/pipeline.log\">pipeline</a>"]},{"id":"ac824d6f-66f5-4a8b-b2e2-d2287194c9fa","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":1027.800574,"created":"2024-11-06T12:19:36.598524","updated":"2024-11-06T12:19:36.598532","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac824d6f-66f5-4a8b-b2e2-d2287194c9fa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac824d6f-66f5-4a8b-b2e2-d2287194c9fa/pipeline.log\">pipeline</a>"]},{"id":"a830f14b-dc7d-4ff0-b563-78cc0e641fa0","name":"RHEL9 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1057.176733,"created":"2024-11-06T12:20:07.982558","updated":"2024-11-06T12:20:07.982564","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a830f14b-dc7d-4ff0-b563-78cc0e641fa0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a830f14b-dc7d-4ff0-b563-78cc0e641fa0/pipeline.log\">pipeline</a>"]},{"id":"c2eae5bf-ff67-45de-b8db-ef65a222e0ed","name":"RHEL8 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1215.598666,"created":"2024-11-06T12:20:01.383092","updated":"2024-11-06T12:20:01.383098","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2eae5bf-ff67-45de-b8db-ef65a222e0ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2eae5bf-ff67-45de-b8db-ef65a222e0ed/pipeline.log\">pipeline</a>"]},{"id":"7ace6176-23ff-4277-abb1-b9a18c0141a3","name":"RHEL8 - PyTest - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1250.950388,"created":"2024-11-06T12:20:02.786379","updated":"2024-11-06T12:20:02.786385","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ace6176-23ff-4277-abb1-b9a18c0141a3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ace6176-23ff-4277-abb1-b9a18c0141a3/pipeline.log\">pipeline</a>"]},{"id":"56a58194-1858-49af-a974-6b6f3c3aae28","name":"RHEL8 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1288.904651,"created":"2024-11-06T12:20:09.148646","updated":"2024-11-06T12:20:09.148652","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/56a58194-1858-49af-a974-6b6f3c3aae28\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/56a58194-1858-49af-a974-6b6f3c3aae28/pipeline.log\">pipeline</a>"]},{"id":"462213b8-26ac-4ffd-b8eb-43a8439e45a8","name":"RHEL9 - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1281.927311,"created":"2024-11-06T12:21:57.243727","updated":"2024-11-06T12:21:57.243736","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/462213b8-26ac-4ffd-b8eb-43a8439e45a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/462213b8-26ac-4ffd-b8eb-43a8439e45a8/pipeline.log\">pipeline</a>"]},{"id":"7418e5bb-e4f5-4486-b708-2017d8cc23f3","name":"RHEL9 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1230.507337,"created":"2024-11-06T12:27:13.691353","updated":"2024-11-06T12:27:13.691359","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7418e5bb-e4f5-4486-b708-2017d8cc23f3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7418e5bb-e4f5-4486-b708-2017d8cc23f3/pipeline.log\">pipeline</a>"]},{"id":"30de065b-640d-4436-8ff2-97d957e5a189","name":"RHEL8 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1346.782702,"created":"2024-11-06T12:26:22.363839","updated":"2024-11-06T12:26:22.363845","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30de065b-640d-4436-8ff2-97d957e5a189\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30de065b-640d-4436-8ff2-97d957e5a189/pipeline.log\">pipeline</a>"]},{"id":"7a59d6a4-8d91-4d45-aa7c-7a81087ddb4e","name":"RHEL8 - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1457.257669,"created":"2024-11-06T12:27:16.217502","updated":"2024-11-06T12:27:16.217509","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a59d6a4-8d91-4d45-aa7c-7a81087ddb4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a59d6a4-8d91-4d45-aa7c-7a81087ddb4e/pipeline.log\">pipeline</a>"]},{"id":"14c6665a-7e14-4dff-9e21-0b07c37ded5c","name":"RHEL9 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1245.481644,"created":"2024-11-06T12:32:13.284518","updated":"2024-11-06T12:32:13.284524","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/14c6665a-7e14-4dff-9e21-0b07c37ded5c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/14c6665a-7e14-4dff-9e21-0b07c37ded5c/pipeline.log\">pipeline</a>"]},{"id":"f1f5be32-c240-4d6e-b7b4-86c83c195a33","name":"RHEL8 - OpenShift 4 - 1.24","runTime":1416.345815,"created":"2024-11-06T12:31:31.073591","updated":"2024-11-06T12:31:31.073598","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1f5be32-c240-4d6e-b7b4-86c83c195a33\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1f5be32-c240-4d6e-b7b4-86c83c195a33/pipeline.log\">pipeline</a>"]}]} -->