### PR TITLE
Enable testing nginx-container on RHEL10 host.

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "1.20", "1.22", "1.22-micro", "1.24", "1.26" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s", "rhel9-unsubscribed" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s", "rhel9-unsubscribed" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "1.20", "1.22", "1.22-micro", "1.24", "1.26" ]
-        os_test: [ "rhel8", "rhel9"]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "1.20", "1.22", "1.22-micro", "1.24", "1.26" ]
-        os_test: [ "rhel8", "rhel9" ]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
     steps:
       - uses: sclorg/tfaga-wrapper@main


### PR DESCRIPTION
This pull request enables testing nginx-container on RHEL10 host.

It updates only Git Hub Action. No code is modifed.


<!-- issue-commentator = {"comment-id":"2590111265"} -->













































































<!-- testing-farm = {"lock":"false","comment-id":"2590129833","data":[{"id":"046f558b-2081-47bf-9daa-0cf9a526cbb1","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":442.45369,"created":"2025-01-14T14:42:44.782410","updated":"2025-01-14T14:42:44.782420","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/046f558b-2081-47bf-9daa-0cf9a526cbb1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/046f558b-2081-47bf-9daa-0cf9a526cbb1/pipeline.log\">pipeline</a>"]},{"id":"d2676d92-a78c-4aef-ae33-14bc10825c57","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":502.675417,"created":"2025-01-14T14:42:39.317088","updated":"2025-01-14T14:42:39.317096","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d2676d92-a78c-4aef-ae33-14bc10825c57\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d2676d92-a78c-4aef-ae33-14bc10825c57/pipeline.log\">pipeline</a>"]},{"id":"53a3cf41-00ff-49bf-9cae-008a3758a323","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":555.438111,"created":"2025-01-14T14:42:46.187977","updated":"2025-01-14T14:42:46.187987","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/53a3cf41-00ff-49bf-9cae-008a3758a323\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/53a3cf41-00ff-49bf-9cae-008a3758a323/pipeline.log\">pipeline</a>"]},{"id":"3890c93c-a5ea-4e16-a4f2-8c03179ad4df","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":669.073135,"created":"2025-01-14T14:42:45.706407","updated":"2025-01-14T14:42:45.706415","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3890c93c-a5ea-4e16-a4f2-8c03179ad4df\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3890c93c-a5ea-4e16-a4f2-8c03179ad4df/pipeline.log\">pipeline</a>"]},{"id":"c20909f2-3ac0-4dc7-9c79-2b2817466607","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":695.879626,"created":"2025-01-14T14:42:35.734767","updated":"2025-01-14T14:42:35.734775","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c20909f2-3ac0-4dc7-9c79-2b2817466607\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c20909f2-3ac0-4dc7-9c79-2b2817466607/pipeline.log\">pipeline</a>"]},{"id":"5adce9c1-68a4-42d7-93c3-cd912e566e8c","name":"RHEL9 - Unsubscribed host - 1.24","status":"complete","outcome":"passed","runTime":717.96657,"created":"2025-01-14T14:42:44.900935","updated":"2025-01-14T14:42:44.900942","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5adce9c1-68a4-42d7-93c3-cd912e566e8c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5adce9c1-68a4-42d7-93c3-cd912e566e8c/pipeline.log\">pipeline</a>"]},{"id":"de97d30f-4b21-41e7-9ad5-f9b74ecbb252","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":738.914162,"created":"2025-01-14T14:42:37.595992","updated":"2025-01-14T14:42:37.596000","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/de97d30f-4b21-41e7-9ad5-f9b74ecbb252\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/de97d30f-4b21-41e7-9ad5-f9b74ecbb252/pipeline.log\">pipeline</a>"]},{"id":"9bdf9cf3-8b9d-471f-adeb-9fbde73b5941","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":728.040462,"created":"2025-01-14T14:42:44.104435","updated":"2025-01-14T14:42:44.104441","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bdf9cf3-8b9d-471f-adeb-9fbde73b5941\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bdf9cf3-8b9d-471f-adeb-9fbde73b5941/pipeline.log\">pipeline</a>"]},{"id":"d8bc5511-5172-4ce1-859c-49fb00da1dd6","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":727.722405,"created":"2025-01-14T14:42:34.815871","updated":"2025-01-14T14:42:34.815877","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8bc5511-5172-4ce1-859c-49fb00da1dd6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8bc5511-5172-4ce1-859c-49fb00da1dd6/pipeline.log\">pipeline</a>"]},{"id":"4f214ed5-084a-438a-81fb-922c5982cb6b","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":775.889458,"created":"2025-01-14T14:42:34.983237","updated":"2025-01-14T14:42:34.983245","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f214ed5-084a-438a-81fb-922c5982cb6b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f214ed5-084a-438a-81fb-922c5982cb6b/pipeline.log\">pipeline</a>"]},{"id":"517f580a-b550-443d-a9b7-d368574d588e","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":916.65202,"created":"2025-01-14T14:42:36.473277","updated":"2025-01-14T14:42:36.473284","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/517f580a-b550-443d-a9b7-d368574d588e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/517f580a-b550-443d-a9b7-d368574d588e/pipeline.log\">pipeline</a>"]},{"id":"15eebad7-76bf-4c4f-a8b8-f5fec3235754","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":968.390895,"created":"2025-01-14T14:42:36.825675","updated":"2025-01-14T14:42:36.825680","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/15eebad7-76bf-4c4f-a8b8-f5fec3235754\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/15eebad7-76bf-4c4f-a8b8-f5fec3235754/pipeline.log\">pipeline</a>"]},{"id":"2b302969-6b88-4e10-a30d-b1dc81279531","name":"RHEL8 - 1.24","runTime":1036.020215,"created":"2025-01-14T14:42:43.088938","updated":"2025-01-14T14:42:43.088946","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b302969-6b88-4e10-a30d-b1dc81279531\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b302969-6b88-4e10-a30d-b1dc81279531/pipeline.log\">pipeline</a>"]}]} -->