### PR TITLE
Building and testing nginx-container on RHEL 10

### DIFF
--- a/1.26/Dockerfile.rhel10
+++ b/1.26/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM registry.stage.redhat.io/ubi10/s2i-core
+FROM ubi10/s2i-core
 
 EXPOSE 8080
 EXPOSE 8443

--- a/1.26/Dockerfile.rhel10
+++ b/1.26/Dockerfile.rhel10
@@ -1,0 +1,88 @@
+FROM registry.stage.redhat.io/ubi10/s2i-core
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV NAME=nginx \
+    NGINX_VERSION=1.26 \
+    NGINX_SHORT_VER=126 \
+    VERSION=0
+
+ENV SUMMARY="Platform for running nginx $NGINX_VERSION or building nginx-based application" \
+    DESCRIPTION="Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and IMAP \
+protocols, with a strong focus on high concurrency, performance and low memory usage. The container \
+image provides a containerized packaging of the nginx $NGINX_VERSION daemon. The image can be used \
+as a base image for other applications based on nginx $NGINX_VERSION web server. \
+Nginx server image can be extended using source-to-image tool."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Nginx ${NGINX_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.expose-services="8443:https" \
+      io.openshift.tags="builder,${NAME},${NAME}-${NGINX_SHORT_VER}" \
+      com.redhat.component="${NAME}-${NGINX_SHORT_VER}-container" \
+      name="rhel10/nginx-${NGINX_SHORT_VER}" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
+      help="For more information visit https://github.com/sclorg/${NAME}-container" \
+      usage="s2i build <SOURCE-REPOSITORY> rhel10/nginx-${NGINX_SHORT_VER}:latest <APP-NAME>"
+
+ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
+    NGINX_CONF_PATH=/etc/nginx/nginx.conf \
+    NGINX_DEFAULT_CONF_PATH=${APP_ROOT}/etc/nginx.default.d \
+    NGINX_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nginx \
+    NGINX_APP_ROOT=${APP_ROOT} \
+    NGINX_LOG_PATH=/var/log/nginx \
+    NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
+
+# Modules does not exist
+RUN INSTALL_PKGS="nss_wrapper-libs bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \
+    dnf -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY $NGINX_VERSION/s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY $NGINX_VERSION/root/ /
+
+# Changing ownership and user rights to support following use-cases:
+# 1) running container on OpenShift, whose default security model
+#    is to run the container under random UID, but GID=0
+# 2) for working root-less container with UID=1001, which does not have
+#    to have GID=0
+# 3) for default use-case, that is running container directly on operating system,
+#    with default UID and GID (1001:0)
+# Supported combinations of UID:GID are thus following:
+# UID=1001 && GID=0
+# UID=<any>&& GID=0
+# UID=1001 && GID=<any>
+RUN sed -i -f ${NGINX_APP_ROOT}/nginxconf.sed ${NGINX_CONF_PATH} && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
+    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
+    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    mkdir -p ${NGINX_LOG_PATH} && \
+    mkdir -p ${NGINX_PERL_MODULE_PATH} && \
+    chown -R 1001:0 ${NGINX_CONF_PATH} && \
+    chown -R 1001:0 ${NGINX_APP_ROOT}/etc && \
+    chown -R 1001:0 ${NGINX_APP_ROOT}/src/nginx-start/  && \
+    chown -R 1001:0 ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod    ug+rw  ${NGINX_CONF_PATH} && \
+    chmod -R ug+rwX ${NGINX_APP_ROOT}/etc && \
+    chmod -R ug+rwX ${NGINX_APP_ROOT}/src/nginx-start/  && \
+    chmod -R ug+rwX ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run && \
+    rpm-file-permissions
+
+USER 1001
+
+STOPSIGNAL SIGQUIT
+
+CMD $STI_SCRIPTS_PATH/usage

--- a/1.26/Dockerfile.rhel10
+++ b/1.26/Dockerfile.rhel10
@@ -23,12 +23,12 @@ LABEL summary="${SUMMARY}" \
       io.openshift.expose-services="8443:https" \
       io.openshift.tags="builder,${NAME},${NAME}-${NGINX_SHORT_VER}" \
       com.redhat.component="${NAME}-${NGINX_SHORT_VER}-container" \
-      name="rhel10/nginx-${NGINX_SHORT_VER}" \
+      name="ubi10/nginx-${NGINX_SHORT_VER}" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/${NAME}-container" \
-      usage="s2i build <SOURCE-REPOSITORY> rhel10/nginx-${NGINX_SHORT_VER}:latest <APP-NAME>"
+      usage="s2i build <SOURCE-REPOSITORY> ubi10/nginx-${NGINX_SHORT_VER} <APP-NAME>"
 
 ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_CONF_PATH=/etc/nginx/nginx.conf \

--- a/1.26/README.md
+++ b/1.26/README.md
@@ -199,6 +199,7 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/nginx-container.
 In that repository you also can find another versions of Python environment Dockerfiles.
-for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`,
+for RHEL8 it's `Dockerfile.rhel8`, Dockerfile for RHEL10 is called `Dockerfile.rhel10`,
+Dockerfile for CentOS Stream 9 is called `Dockerfile.c9s`,
 Dockerfile for CentOS Stream 10 is called `Dockerfile.c10s`, and the Fedora Dockerfile is called `Dockerfile.fedora`.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Nginx versions currently provided are:
 RHEL versions currently supported are:
 * RHEL8
 * RHEL9
+* RHEL10
 
 CentOS Stream versions currently supported are:
 * CentOS Stream 9


### PR DESCRIPTION
This pull request supports building and testing nginx-container on RHEL 10 quest.

The first commit adds Dockerfile.rhel10 for building and testing.
The second commit updates README.md files



<!-- issue-commentator = {"comment-id":"2590652429"} -->

























































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2590688493","data":[{"id":"0c4b510f-4a95-4dd0-a0ab-9657c2f58e3c","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":252.195932,"created":"2025-01-22T08:04:27.377519","updated":"2025-01-22T08:04:27.377528","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0c4b510f-4a95-4dd0-a0ab-9657c2f58e3c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0c4b510f-4a95-4dd0-a0ab-9657c2f58e3c/pipeline.log\">pipeline</a>"]},{"id":"3c18e050-f493-4184-a5ad-4ed3c41b9dc8","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":316.000579,"created":"2025-01-22T08:03:25.444305","updated":"2025-01-22T08:03:25.444313","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3c18e050-f493-4184-a5ad-4ed3c41b9dc8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3c18e050-f493-4184-a5ad-4ed3c41b9dc8/pipeline.log\">pipeline</a>"]},{"id":"8a7eccb2-177e-4b6e-9b03-3341630ed8a5","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":347.087079,"created":"2025-01-22T08:03:32.621185","updated":"2025-01-22T08:03:32.621191","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8a7eccb2-177e-4b6e-9b03-3341630ed8a5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8a7eccb2-177e-4b6e-9b03-3341630ed8a5/pipeline.log\">pipeline</a>"]},{"id":"019d7d90-4485-456d-9218-1da5f5e7684c","name":"RHEL10 - 1.26","status":"complete","outcome":"passed","runTime":776.111819,"created":"2025-01-22T08:03:36.540031","updated":"2025-01-22T08:03:36.540037","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/019d7d90-4485-456d-9218-1da5f5e7684c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/019d7d90-4485-456d-9218-1da5f5e7684c/pipeline.log\">pipeline</a>"]},{"id":"3e11db51-b57f-4a05-88a4-e5785bb54cd7","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":656.888233,"created":"2025-01-22T08:03:23.996470","updated":"2025-01-22T08:03:23.996479","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e11db51-b57f-4a05-88a4-e5785bb54cd7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e11db51-b57f-4a05-88a4-e5785bb54cd7/pipeline.log\">pipeline</a>"]},{"id":"463c1a07-b17e-4adf-b377-2858c559aa8c","name":"RHEL9 - Unsubscribed host - 1.24","status":"complete","outcome":"passed","runTime":687.146626,"created":"2025-01-22T08:03:36.482856","updated":"2025-01-22T08:03:36.482863","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/463c1a07-b17e-4adf-b377-2858c559aa8c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/463c1a07-b17e-4adf-b377-2858c559aa8c/pipeline.log\">pipeline</a>"]},{"id":"7ceea237-f8d8-446c-a900-d44e7cea3f11","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":466.220067,"created":"2025-01-22T08:03:37.315537","updated":"2025-01-22T08:03:37.315544","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7ceea237-f8d8-446c-a900-d44e7cea3f11\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7ceea237-f8d8-446c-a900-d44e7cea3f11/pipeline.log\">pipeline</a>"]},{"id":"df70510d-47d4-4b3a-ae57-c1af98f8a660","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":679.892586,"created":"2025-01-22T08:03:25.566490","updated":"2025-01-22T08:03:25.566497","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df70510d-47d4-4b3a-ae57-c1af98f8a660\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df70510d-47d4-4b3a-ae57-c1af98f8a660/pipeline.log\">pipeline</a>"]},{"id":"8fe85381-ca4b-4095-acd5-44e9320d67b5","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":753.524924,"created":"2025-01-22T08:03:27.792758","updated":"2025-01-22T08:03:27.792767","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8fe85381-ca4b-4095-acd5-44e9320d67b5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8fe85381-ca4b-4095-acd5-44e9320d67b5/pipeline.log\">pipeline</a>"]},{"id":"d98f77b0-8f3b-4722-8e27-45d44edaba2d","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":716.779237,"created":"2025-01-22T08:03:27.449906","updated":"2025-01-22T08:03:27.449913","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d98f77b0-8f3b-4722-8e27-45d44edaba2d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d98f77b0-8f3b-4722-8e27-45d44edaba2d/pipeline.log\">pipeline</a>"]},{"id":"3cd99119-7d66-4dee-9b52-03c4496f7387","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":764.891152,"created":"2025-01-22T08:03:33.998041","updated":"2025-01-22T08:03:33.998050","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cd99119-7d66-4dee-9b52-03c4496f7387\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cd99119-7d66-4dee-9b52-03c4496f7387/pipeline.log\">pipeline</a>"]},{"id":"74fb02f2-20ff-4eac-9ccd-ff9d03d0b006","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":909.097425,"created":"2025-01-22T08:03:24.054290","updated":"2025-01-22T08:03:24.054296","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74fb02f2-20ff-4eac-9ccd-ff9d03d0b006\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74fb02f2-20ff-4eac-9ccd-ff9d03d0b006/pipeline.log\">pipeline</a>"]},{"id":"8c849db1-40c9-44ad-9b21-ee8857cd5b28","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":890.015208,"created":"2025-01-22T08:03:33.048003","updated":"2025-01-22T08:03:33.048014","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c849db1-40c9-44ad-9b21-ee8857cd5b28\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c849db1-40c9-44ad-9b21-ee8857cd5b28/pipeline.log\">pipeline</a>"]},{"id":"bef0eec8-ed26-4069-b3f5-b2711c2ccf68","name":"RHEL8 - 1.22-micro","runTime":943.24865,"created":"2025-01-22T08:03:27.040172","updated":"2025-01-22T08:03:27.040196","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bef0eec8-ed26-4069-b3f5-b2711c2ccf68\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bef0eec8-ed26-4069-b3f5-b2711c2ccf68/pipeline.log\">pipeline</a>"]}]} -->