### PR TITLE
Fix nginx-container OpenShift 4 tests

### DIFF
--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -10,4 +10,4 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 git show -s
 
-cd "${THISDIR}" && python3.12 -m pytest -s -rA --showlocals -vv test_nginx_*.py
+cd "${THISDIR}" && python3.12 -m pytest -s -rA --showlocals -vv test_*.py

--- a/test/test_nginx_imagestream_s2i.py
+++ b/test/test_nginx_imagestream_s2i.py
@@ -14,6 +14,11 @@ IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("OS")
 VERSION = os.getenv("VERSION")
 
+TAGS = {
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9"
+}
+TAG = TAGS.get(OS, None)
 
 # bash test=test_nginx_imagestream
 class TestNginxImagestreamS2I:

--- a/test/test_shared_helm_nginx_imagestreams.py
+++ b/test/test_shared_helm_nginx_imagestreams.py
@@ -18,7 +18,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELNginxImageStreams:
 
     def setup_method(self):
-        package_name = "nginx-imagestreams"
+        package_name = "redhat-nginx-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
@@ -30,17 +30,17 @@ class TestHelmRHELNginxImageStreams:
         self.hc_api.delete_project()
 
     @pytest.mark.parametrize(
-        "version,registry",
+        "version,registry,expected",
         [
-            ("1.24-ubi9", "registry.redhat.io/ubi9/nginx-124:latest"),
-            ("1.24-ubi8", "registry.redhat.io/ubi8/nginx-124:latest"),
-            ("1.22-ubi9", "registry.redhat.io/ubi9/nginx-122:latest"),
-            ("1.22-ubi8", "registry.redhat.io/ubi8/nginx-122:latest"),
-            ("1.20-ubi9", "registry.redhat.io/ubi9/nginx-120:latest"),
-            ("1.20-ubi8", "registry.redhat.io/ubi8/nginx-120:latest"),
+            ("1.24-ubi9", "registry.redhat.io/ubi9/nginx-124:latest", True),
+            ("1.24-ubi8", "registry.redhat.io/ubi8/nginx-124:latest", True),
+            ("1.22-ubi9", "registry.redhat.io/ubi9/nginx-122:latest", True),
+            ("1.22-ubi8", "registry.redhat.io/ubi8/nginx-122:latest", True),
+            ("1.20-ubi9", "registry.redhat.io/ubi9/nginx-120:latest", True),
+            ("1.20-ubi8", "registry.redhat.io/ubi8/nginx-120:latest", False),
         ],
     )
-    def test_package_imagestream(self, version, registry):
+    def test_package_imagestream(self, version, registry, expected):
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        assert self.hc_api.check_imagestreams(version=version, registry=registry)
+        assert self.hc_api.check_imagestreams(version=version, registry=registry) == expected

--- a/test/test_shared_helm_nginx_template.py
+++ b/test/test_shared_helm_nginx_template.py
@@ -29,9 +29,9 @@ TAG = TAGS.get(OS, None)
 class TestHelmNginxTemplate:
 
     def setup_method(self):
-        package_name = "nginx-template"
+        package_name = "redhat-nginx-template"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -41,15 +41,15 @@ class TestHelmNginxTemplate:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
-        if self.hc_api.oc_api.shared_cluster:
+        if self.hc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")
-        self.hc_api.package_name = "nginx-imagestreams"
+        self.hc_api.package_name = "redhat-nginx-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "nginx-template"
+        self.hc_api.package_name = "redhat-nginx-template"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -65,13 +65,13 @@ class TestHelmNginxTemplate:
         )
 
     def test_helm_connection(self):
-        self.hc_api.package_name = "nginx-imagestreams"
+        self.hc_api.package_name = "redhat-nginx-imagestreams"
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "nginx-template"
+        self.hc_api.package_name = "redhat-nginx-template"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2656067063"} -->





















































<!-- testing-farm = {"lock":"false","comment-id":"2656114637","data":[{"id":"a0ed06e6-2838-48bf-9e72-3e38469f3ef4","name":"RHEL9 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1097.27648,"created":"2025-02-13T09:53:47.707674","updated":"2025-02-13T09:53:47.707683","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0ed06e6-2838-48bf-9e72-3e38469f3ef4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0ed06e6-2838-48bf-9e72-3e38469f3ef4/pipeline.log\">pipeline</a>"]},{"id":"f4a9b9ac-89d5-4be0-9e44-b41b6a06ae31","name":"RHEL9 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":5016.876182,"created":"2025-02-13T11:59:18.532752","updated":"2025-02-13T11:59:18.532760","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4a9b9ac-89d5-4be0-9e44-b41b6a06ae31\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4a9b9ac-89d5-4be0-9e44-b41b6a06ae31/pipeline.log\">pipeline</a>"]},{"id":"54872177-d1b5-4497-81d6-29d2b9d3878d","name":"RHEL9 - PyTest - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":4913.50784,"created":"2025-02-13T11:59:20.717560","updated":"2025-02-13T11:59:20.717566","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/54872177-d1b5-4497-81d6-29d2b9d3878d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/54872177-d1b5-4497-81d6-29d2b9d3878d/pipeline.log\">pipeline</a>"]},{"id":"45dadfbe-3fe9-4b7e-acd7-40e2e9a8ccd0","name":"RHEL8 - PyTest - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1365.532407,"created":"2025-02-13T09:53:47.701377","updated":"2025-02-13T09:53:47.701383","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45dadfbe-3fe9-4b7e-acd7-40e2e9a8ccd0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45dadfbe-3fe9-4b7e-acd7-40e2e9a8ccd0/pipeline.log\">pipeline</a>"]},{"id":"10618ba7-02ee-441b-b803-ec5e56d8acb6","name":"RHEL8 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1408.617757,"created":"2025-02-13T09:53:46.792807","updated":"2025-02-13T09:53:46.792814","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/10618ba7-02ee-441b-b803-ec5e56d8acb6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/10618ba7-02ee-441b-b803-ec5e56d8acb6/pipeline.log\">pipeline</a>"]},{"id":"22dd1b1b-46c0-41bb-8166-19bb26224ddc","name":"RHEL8 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1465.261161,"created":"2025-02-13T09:53:49.315792","updated":"2025-02-13T09:53:49.315798","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22dd1b1b-46c0-41bb-8166-19bb26224ddc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22dd1b1b-46c0-41bb-8166-19bb26224ddc/pipeline.log\">pipeline</a>"]},{"id":"d7c8a670-b343-4cb9-841a-be97395ec883","name":"RHEL10 - PyTest - OpenShift 4 - 1.26","runTime":11074.156707,"created":"2025-02-13T11:59:18.489591","updated":"2025-02-13T11:59:18.489597","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7c8a670-b343-4cb9-841a-be97395ec883\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d7c8a670-b343-4cb9-841a-be97395ec883/pipeline.log\">pipeline</a>"]}]} -->