### PR TITLE
Support testing nginx-container on shared_cluster

### DIFF
--- a/test/test_nginx_imagestream_s2i.py
+++ b/test/test_nginx_imagestream_s2i.py
@@ -16,7 +16,8 @@ VERSION = os.getenv("VERSION")
 
 TAGS = {
     "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10"
 }
 TAG = TAGS.get(OS, None)
 
@@ -31,6 +32,8 @@ class TestNginxImagestreamS2I:
         self.oc_api.delete_project()
 
     def test_inside_cluster(self):
+        if OS == "rhel10":
+            pytest.skip("Skipping test for rhel10")
         os_name = ''.join(i for i in OS if not i.isdigit())
         new_version = VERSION
         if "-minimal" in VERSION:

--- a/test/test_nginx_imagestream_s2i.py
+++ b/test/test_nginx_imagestream_s2i.py
@@ -25,7 +25,7 @@ class TestNginxImagestreamS2I:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_nginx_local_example.py
+++ b/test/test_nginx_local_example.py
@@ -19,7 +19,7 @@ class TestNginxLocalEx:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_nginx_remote_example.py
+++ b/test/test_nginx_remote_example.py
@@ -20,7 +20,7 @@ class TestNginxLocalEx:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_nginx_template_example_app.py
+++ b/test/test_nginx_template_example_app.py
@@ -28,6 +28,8 @@ class TestNginxDeployTemplate:
         self.oc_api.delete_project()
 
     def test_python_template_inside_cluster(self):
+        if OS == "rhel10":
+            pytest.skip("Skipping test for rhel10")
         service_name = "nginx-testing"
         template_url = self.oc_api.get_raw_url_for_json(
             container="nginx-ex", dir="openshift/templates", filename="nginx.json", branch="master"

--- a/test/test_nginx_template_example_app.py
+++ b/test/test_nginx_template_example_app.py
@@ -22,7 +22,7 @@ OS = os.getenv("TARGET")
 class TestNginxDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nginx-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="nginx-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_shared_helm_nginx_template.py
+++ b/test/test_shared_helm_nginx_template.py
@@ -21,7 +21,8 @@ OS = os.getenv("TARGET")
 
 TAGS = {
     "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10",
 }
 TAG = TAGS.get(OS, None)
 
@@ -65,6 +66,8 @@ class TestHelmNginxTemplate:
         )
 
     def test_helm_connection(self):
+        if OS == "rhel10":
+            pytest.skip("Skipping test for rhel10")
         self.hc_api.package_name = "redhat-nginx-imagestreams"
         new_version = VERSION
         if "micro" in VERSION:


### PR DESCRIPTION
This pull request enables testing nginx-container on shared cluster

The nginx-container code is not changed at all.







































































































<!-- issue-commentator = {"comment-id":"2697584998"} -->





















































































































































<!-- testing-farm = {"lock":"false","comment-id":"2697377664","data":[{"id":"f0085752-9bfc-4716-8e4c-f0a57db31104","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":513.945651,"created":"2025-03-04T12:11:30.897259","updated":"2025-03-04T12:11:30.897266","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f0085752-9bfc-4716-8e4c-f0a57db31104\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f0085752-9bfc-4716-8e4c-f0a57db31104/pipeline.log\">pipeline</a>"]},{"id":"8d4342a8-38ce-4374-ac32-93c4e309df3e","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":518.188022,"created":"2025-03-04T12:15:16.361815","updated":"2025-03-04T12:15:16.361821","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8d4342a8-38ce-4374-ac32-93c4e309df3e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8d4342a8-38ce-4374-ac32-93c4e309df3e/pipeline.log\">pipeline</a>"]},{"id":"5c88b4b5-4938-4d88-bc6c-913fbafdd6ff","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":458.36921,"created":"2025-03-04T12:16:36.723665","updated":"2025-03-04T12:16:36.723671","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5c88b4b5-4938-4d88-bc6c-913fbafdd6ff\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5c88b4b5-4938-4d88-bc6c-913fbafdd6ff/pipeline.log\">pipeline</a>"]},{"id":"a35f2505-c420-4ee1-89ca-5b9b047cb7c0","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":518.833866,"created":"2025-03-04T12:17:38.303735","updated":"2025-03-04T12:17:38.303744","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a35f2505-c420-4ee1-89ca-5b9b047cb7c0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a35f2505-c420-4ee1-89ca-5b9b047cb7c0/pipeline.log\">pipeline</a>"]},{"id":"b0d96470-32b4-44aa-8179-52468110579f","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":1736.45827,"created":"2025-03-04T12:11:20.650341","updated":"2025-03-04T12:11:20.650347","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b0d96470-32b4-44aa-8179-52468110579f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b0d96470-32b4-44aa-8179-52468110579f/pipeline.log\">pipeline</a>"]},{"id":"12053088-e4dc-4fba-a3d2-885c494048fe","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":1752.172672,"created":"2025-03-04T12:11:23.144938","updated":"2025-03-04T12:11:23.144945","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/12053088-e4dc-4fba-a3d2-885c494048fe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/12053088-e4dc-4fba-a3d2-885c494048fe/pipeline.log\">pipeline</a>"]},{"id":"c6d37ebb-fa21-410c-95c2-16ae442d35a0","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":3084.589787,"created":"2025-03-04T12:10:55.442241","updated":"2025-03-04T12:10:55.442248","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c6d37ebb-fa21-410c-95c2-16ae442d35a0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c6d37ebb-fa21-410c-95c2-16ae442d35a0/pipeline.log\">pipeline</a>"]},{"id":"22b5df4d-536c-4dbc-a806-314907b106a3","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":2876.657041,"created":"2025-03-04T12:15:45.175185","updated":"2025-03-04T12:15:45.175195","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22b5df4d-536c-4dbc-a806-314907b106a3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22b5df4d-536c-4dbc-a806-314907b106a3/pipeline.log\">pipeline</a>"]},{"id":"204479b7-c6b2-407b-88f0-47fcb9faf069","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":3168.4568,"created":"2025-03-04T12:10:58.812634","updated":"2025-03-04T12:10:58.812641","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/204479b7-c6b2-407b-88f0-47fcb9faf069\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/204479b7-c6b2-407b-88f0-47fcb9faf069/pipeline.log\">pipeline</a>"]},{"id":"d31b15e3-b712-46a0-8147-01761ec8eb4e","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":3070.989085,"created":"2025-03-04T12:12:57.816326","updated":"2025-03-04T12:12:57.816333","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d31b15e3-b712-46a0-8147-01761ec8eb4e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d31b15e3-b712-46a0-8147-01761ec8eb4e/pipeline.log\">pipeline</a>"]},{"id":"1ba2a679-2c52-4a46-8771-7b3261ae5f6a","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":2947.207534,"created":"2025-03-04T12:15:50.155221","updated":"2025-03-04T12:15:50.155227","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ba2a679-2c52-4a46-8771-7b3261ae5f6a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1ba2a679-2c52-4a46-8771-7b3261ae5f6a/pipeline.log\">pipeline</a>"]},{"id":"cf611427-34ea-4e36-a17a-254036fb23a7","name":"RHEL9 - Unsubscribed host - 1.24","status":"complete","outcome":"passed","runTime":2961.106528,"created":"2025-03-04T12:16:03.267786","updated":"2025-03-04T12:16:03.267792","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf611427-34ea-4e36-a17a-254036fb23a7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf611427-34ea-4e36-a17a-254036fb23a7/pipeline.log\">pipeline</a>"]},{"id":"e7bfef6b-e8b6-4b92-acb3-de7db020eb2b","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":3198.385217,"created":"2025-03-04T12:14:50.505813","updated":"2025-03-04T12:14:50.505819","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7bfef6b-e8b6-4b92-acb3-de7db020eb2b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7bfef6b-e8b6-4b92-acb3-de7db020eb2b/pipeline.log\">pipeline</a>"]},{"id":"41acc3e4-3077-43b7-98ba-7bc81cfb369d","name":"RHEL10 - 1.26","status":"complete","outcome":"error","runTime":3081.462643,"created":"2025-03-04T12:19:20.876325","updated":"2025-03-04T12:19:20.876332","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/41acc3e4-3077-43b7-98ba-7bc81cfb369d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/41acc3e4-3077-43b7-98ba-7bc81cfb369d/pipeline.log\">pipeline</a>"]},{"id":"69c45543-25c8-4114-8bd0-9bd1978295e8","name":"RHEL9 - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1037.716206,"created":"2025-03-04T14:25:31.536477","updated":"2025-03-04T14:25:31.536483","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/69c45543-25c8-4114-8bd0-9bd1978295e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/69c45543-25c8-4114-8bd0-9bd1978295e8/pipeline.log\">pipeline</a>"]},{"id":"b98b6f11-8e8e-4085-b600-89c894b24e53","name":"RHEL9 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1057.029169,"created":"2025-03-04T14:35:52.849262","updated":"2025-03-04T14:35:52.849274","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b98b6f11-8e8e-4085-b600-89c894b24e53\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b98b6f11-8e8e-4085-b600-89c894b24e53/pipeline.log\">pipeline</a>"]},{"id":"14e11f36-aba0-40f4-a87c-b971385011aa","name":"RHEL8 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1222.494893,"created":"2025-03-04T14:35:48.916171","updated":"2025-03-04T14:35:48.916178","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/14e11f36-aba0-40f4-a87c-b971385011aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/14e11f36-aba0-40f4-a87c-b971385011aa/pipeline.log\">pipeline</a>"]},{"id":"2aa0a471-9161-4736-aa10-2a3fb311962b","name":"RHEL10 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":962.253524,"created":"2025-03-04T14:40:42.882222","updated":"2025-03-04T14:40:42.882228","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2aa0a471-9161-4736-aa10-2a3fb311962b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2aa0a471-9161-4736-aa10-2a3fb311962b/pipeline.log\">pipeline</a>"]},{"id":"7f9d91a0-3f80-47cd-9256-76639cecc1bc","name":"RHEL9 - OpenShift 4 - 1.24","runTime":1277.817309,"created":"2025-03-04T14:40:42.310104","updated":"2025-03-04T14:40:42.310135","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f9d91a0-3f80-47cd-9256-76639cecc1bc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f9d91a0-3f80-47cd-9256-76639cecc1bc/pipeline.log\">pipeline</a>"]},{"id":"4b42e616-8db2-49e4-8eff-f35a7e6377c8","name":"RHEL8 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1249.278654,"created":"2025-03-04T14:39:12.328426","updated":"2025-03-04T14:39:12.328432","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b42e616-8db2-49e4-8eff-f35a7e6377c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b42e616-8db2-49e4-8eff-f35a7e6377c8/pipeline.log\">pipeline</a>"]},{"id":"6e997323-ad30-4d94-b983-c2f749161c93","name":"RHEL8 - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1336.255038,"created":"2025-03-04T14:38:12.973130","updated":"2025-03-04T14:38:12.973137","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e997323-ad30-4d94-b983-c2f749161c93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e997323-ad30-4d94-b983-c2f749161c93/pipeline.log\">pipeline</a>"]},{"id":"5fcb2391-065d-4a2a-8244-5dc19952011f","name":"RHEL10 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":732.403488,"created":"2025-03-04T14:22:40.605580","updated":"2025-03-04T14:22:40.605589","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5fcb2391-065d-4a2a-8244-5dc19952011f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5fcb2391-065d-4a2a-8244-5dc19952011f/pipeline.log\">pipeline</a>"]},{"id":"9cac58f2-d3e4-4dac-b702-e215a3df0bca","name":"RHEL9 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1066.631793,"created":"2025-03-04T14:22:27.731252","updated":"2025-03-04T14:22:27.731259","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cac58f2-d3e4-4dac-b702-e215a3df0bca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cac58f2-d3e4-4dac-b702-e215a3df0bca/pipeline.log\">pipeline</a>"]},{"id":"7b549063-9b70-4599-b3e9-2e900cc7cd4f","name":"RHEL8 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1267.545183,"created":"2025-03-04T14:22:17.272622","updated":"2025-03-04T14:22:17.272628","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b549063-9b70-4599-b3e9-2e900cc7cd4f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b549063-9b70-4599-b3e9-2e900cc7cd4f/pipeline.log\">pipeline</a>"]},{"id":"dbf07c59-9ecb-4f14-a014-25ab3826898f","name":"RHEL9 - PyTest - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1075.504456,"created":"2025-03-04T14:22:20.104774","updated":"2025-03-04T14:22:20.104780","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dbf07c59-9ecb-4f14-a014-25ab3826898f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dbf07c59-9ecb-4f14-a014-25ab3826898f/pipeline.log\">pipeline</a>"]},{"id":"fd5dbae6-11a9-4c89-9db2-04eb29feae57","name":"RHEL9 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1179.244419,"created":"2025-03-04T14:22:36.002748","updated":"2025-03-04T14:22:36.002754","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd5dbae6-11a9-4c89-9db2-04eb29feae57\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd5dbae6-11a9-4c89-9db2-04eb29feae57/pipeline.log\">pipeline</a>"]},{"id":"25ce79dd-63e8-4400-94e0-534ef00c479d","name":"RHEL8 - PyTest - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1300.822818,"created":"2025-03-04T14:22:27.658942","updated":"2025-03-04T14:22:27.658948","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/25ce79dd-63e8-4400-94e0-534ef00c479d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/25ce79dd-63e8-4400-94e0-534ef00c479d/pipeline.log\">pipeline</a>"]},{"id":"5ed8d212-e0f7-4d52-82da-bec86cdc8bc8","name":"RHEL8 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1349.63742,"created":"2025-03-04T14:22:30.071317","updated":"2025-03-04T14:22:30.071325","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ed8d212-e0f7-4d52-82da-bec86cdc8bc8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ed8d212-e0f7-4d52-82da-bec86cdc8bc8/pipeline.log\">pipeline</a>"]}]} -->