### PR TITLE
Replace 'bind-utils' with 'bind9.18-utils'

### DIFF
--- a/1.20/Dockerfile.rhel9
+++ b/1.20/Dockerfile.rhel9
@@ -38,7 +38,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_LOG_PATH=/var/log/nginx \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
-RUN INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl" && \
+RUN INSTALL_PKGS="nss_wrapper bind9.18-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \

--- a/1.22/Dockerfile.rhel9
+++ b/1.22/Dockerfile.rhel9
@@ -39,7 +39,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper-libs bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl" && \
+    INSTALL_PKGS="nss_wrapper-libs bind9.18-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \

--- a/1.24/Dockerfile.rhel9
+++ b/1.24/Dockerfile.rhel9
@@ -39,7 +39,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper-libs bind-utils gettext hostname nginx nginx-mod-stream nginx-mod-http-perl" && \
+    INSTALL_PKGS="nss_wrapper-libs bind9.18-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \


### PR DESCRIPTION
Replace 'bind-utils' with 'bind9.18-utils'

See Jira issue https://issues.redhat.com/browse/RHEL-80345

It is valid only for RHEL9

<!-- issue-commentator = {"comment-id":"2743374002"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2743387096","data":[{"id":"c6a88cc3-8298-4edf-97b5-9371f38f8a0e","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":311.856722,"created":"2025-03-24T08:01:48.386930","updated":"2025-03-24T08:01:48.386936","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c6a88cc3-8298-4edf-97b5-9371f38f8a0e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c6a88cc3-8298-4edf-97b5-9371f38f8a0e/pipeline.log\">pipeline</a>"]},{"id":"37aa7a59-551d-4009-bdc9-b716c73aea61","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":443.086141,"created":"2025-03-24T08:01:55.098002","updated":"2025-03-24T08:01:55.098010","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/37aa7a59-551d-4009-bdc9-b716c73aea61\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/37aa7a59-551d-4009-bdc9-b716c73aea61/pipeline.log\">pipeline</a>"]},{"id":"a03ad465-5d60-4fa1-9371-ef34a182d856","name":"CentOS Stream 9 - 1.26","status":"complete","outcome":"passed","runTime":329.784818,"created":"2025-03-24T08:01:48.675973","updated":"2025-03-24T08:01:48.675979","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a03ad465-5d60-4fa1-9371-ef34a182d856\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a03ad465-5d60-4fa1-9371-ef34a182d856/pipeline.log\">pipeline</a>"]},{"id":"cb277e37-4618-43fc-b1a3-03301072d7a8","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":275.844495,"created":"2025-03-24T08:01:56.070530","updated":"2025-03-24T08:01:56.070537","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cb277e37-4618-43fc-b1a3-03301072d7a8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cb277e37-4618-43fc-b1a3-03301072d7a8/pipeline.log\">pipeline</a>"]},{"id":"7585236b-7422-47cd-aa31-b73779c67717","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":465.301908,"created":"2025-03-24T08:01:49.344424","updated":"2025-03-24T08:01:49.344430","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7585236b-7422-47cd-aa31-b73779c67717\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7585236b-7422-47cd-aa31-b73779c67717/pipeline.log\">pipeline</a>"]},{"id":"52cfa26f-893b-4f7f-973d-7985cafd76a7","name":"RHEL9 - Unsubscribed host - 1.24","runTime":694.358545,"created":"2025-03-24T11:25:00.460512","updated":"2025-03-24T11:25:00.460520","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/52cfa26f-893b-4f7f-973d-7985cafd76a7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/52cfa26f-893b-4f7f-973d-7985cafd76a7/pipeline.log\">pipeline</a>"]},{"id":"0262a77c-1a94-42c2-8443-f6a1ac5b452a","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":668.075578,"created":"2025-03-24T11:25:00.148102","updated":"2025-03-24T11:25:00.148148","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0262a77c-1a94-42c2-8443-f6a1ac5b452a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0262a77c-1a94-42c2-8443-f6a1ac5b452a/pipeline.log\">pipeline</a>"]},{"id":"7bc8352c-5c00-405c-a786-883084993389","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":669.773863,"created":"2025-03-24T11:24:59.718670","updated":"2025-03-24T11:24:59.718678","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7bc8352c-5c00-405c-a786-883084993389\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7bc8352c-5c00-405c-a786-883084993389/pipeline.log\">pipeline</a>"]},{"id":"6b8e022e-9ab8-44a5-8adc-bc83b6a68c7c","name":"RHEL9 - Unsubscribed host - 1.26","status":"complete","outcome":"passed","runTime":740.022827,"created":"2025-03-24T09:43:29.571218","updated":"2025-03-24T09:43:29.571224","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6b8e022e-9ab8-44a5-8adc-bc83b6a68c7c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6b8e022e-9ab8-44a5-8adc-bc83b6a68c7c/pipeline.log\">pipeline</a>"]},{"id":"be5ee217-3a96-4b9a-84b4-ac99bf4fca61","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":807.300741,"created":"2025-03-24T09:43:29.886337","updated":"2025-03-24T09:43:29.886343","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/be5ee217-3a96-4b9a-84b4-ac99bf4fca61\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/be5ee217-3a96-4b9a-84b4-ac99bf4fca61/pipeline.log\">pipeline</a>"]},{"id":"5d4e3f8f-3cf8-4969-b9d5-5ffbdb5336dc","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":804.284174,"created":"2025-03-24T09:43:29.606841","updated":"2025-03-24T09:43:29.606848","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d4e3f8f-3cf8-4969-b9d5-5ffbdb5336dc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d4e3f8f-3cf8-4969-b9d5-5ffbdb5336dc/pipeline.log\">pipeline</a>"]},{"id":"25c555f8-547b-4cfb-b4ef-6535eae52edd","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":856.65807,"created":"2025-03-24T09:43:29.965154","updated":"2025-03-24T09:43:29.965161","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/25c555f8-547b-4cfb-b4ef-6535eae52edd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/25c555f8-547b-4cfb-b4ef-6535eae52edd/pipeline.log\">pipeline</a>"]},{"id":"4ec2dc81-08ab-449c-a710-cedc0086aab3","name":"RHEL9 - 1.26","status":"complete","outcome":"passed","runTime":875.63513,"created":"2025-03-24T09:43:29.474512","updated":"2025-03-24T09:43:29.474518","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ec2dc81-08ab-449c-a710-cedc0086aab3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ec2dc81-08ab-449c-a710-cedc0086aab3/pipeline.log\">pipeline</a>"]},{"id":"a53878b9-30fc-4feb-8b3e-5a866eba7190","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":981.771892,"created":"2025-03-24T09:43:29.748426","updated":"2025-03-24T09:43:29.748443","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a53878b9-30fc-4feb-8b3e-5a866eba7190\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a53878b9-30fc-4feb-8b3e-5a866eba7190/pipeline.log\">pipeline</a>"]},{"id":"61a31a67-4f7b-45ea-af98-3a3b93416973","name":"RHEL9 - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1082.852145,"created":"2025-03-24T09:55:17.752365","updated":"2025-03-24T09:55:17.752370","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61a31a67-4f7b-45ea-af98-3a3b93416973\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61a31a67-4f7b-45ea-af98-3a3b93416973/pipeline.log\">pipeline</a>"]},{"id":"3a885787-9a17-4336-8710-8046585977f1","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":948.22166,"created":"2025-03-24T09:43:29.279654","updated":"2025-03-24T09:43:29.279663","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a885787-9a17-4336-8710-8046585977f1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a885787-9a17-4336-8710-8046585977f1/pipeline.log\">pipeline</a>"]},{"id":"7ed3b8c2-77b3-4341-84e8-ee9bc85074af","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":1044.087464,"created":"2025-03-24T09:43:30.485269","updated":"2025-03-24T09:43:30.485276","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ed3b8c2-77b3-4341-84e8-ee9bc85074af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ed3b8c2-77b3-4341-84e8-ee9bc85074af/pipeline.log\">pipeline</a>"]},{"id":"6effa4d5-8260-4c56-b259-92b269dbd28e","name":"RHEL10 - 1.26","status":"complete","outcome":"passed","runTime":780.021658,"created":"2025-03-24T09:43:29.617809","updated":"2025-03-24T09:43:29.617816","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6effa4d5-8260-4c56-b259-92b269dbd28e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6effa4d5-8260-4c56-b259-92b269dbd28e/pipeline.log\">pipeline</a>"]},{"id":"6479eeed-8426-4bfc-a7d1-89e7cde1978e","name":"RHEL9 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1126.913885,"created":"2025-03-24T09:57:20.344552","updated":"2025-03-24T09:57:20.344559","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6479eeed-8426-4bfc-a7d1-89e7cde1978e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6479eeed-8426-4bfc-a7d1-89e7cde1978e/pipeline.log\">pipeline</a>"]},{"id":"2bc7321d-e223-4b64-9d4d-d75f05e26f12","name":"RHEL9 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1185.05756,"created":"2025-03-24T09:57:05.990873","updated":"2025-03-24T09:57:05.990883","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2bc7321d-e223-4b64-9d4d-d75f05e26f12\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2bc7321d-e223-4b64-9d4d-d75f05e26f12/pipeline.log\">pipeline</a>"]},{"id":"5a472cb7-341c-4fd3-91bb-a6b370f9b095","name":"RHEL9 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1247.774616,"created":"2025-03-24T09:57:19.783209","updated":"2025-03-24T09:57:19.783217","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a472cb7-341c-4fd3-91bb-a6b370f9b095\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a472cb7-341c-4fd3-91bb-a6b370f9b095/pipeline.log\">pipeline</a>"]},{"id":"454e532b-ef38-4f8b-bc8a-98e471e2321d","name":"RHEL8 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1394.76705,"created":"2025-03-24T09:57:38.706895","updated":"2025-03-24T09:57:38.706901","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/454e532b-ef38-4f8b-bc8a-98e471e2321d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/454e532b-ef38-4f8b-bc8a-98e471e2321d/pipeline.log\">pipeline</a>"]},{"id":"329b2313-727a-43b2-9c0d-c740394b01de","name":"RHEL8 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1347.767977,"created":"2025-03-24T09:58:48.208034","updated":"2025-03-24T09:58:48.208041","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/329b2313-727a-43b2-9c0d-c740394b01de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/329b2313-727a-43b2-9c0d-c740394b01de/pipeline.log\">pipeline</a>"]},{"id":"2adb7765-918b-449f-a2e8-61830ec2b957","name":"RHEL10 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1074.951306,"created":"2025-03-24T09:58:06.138912","updated":"2025-03-24T09:58:06.138920","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2adb7765-918b-449f-a2e8-61830ec2b957\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2adb7765-918b-449f-a2e8-61830ec2b957/pipeline.log\">pipeline</a>"]},{"id":"4ead5d0b-d8f4-447e-be12-fa265bc4177e","name":"RHEL8 - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1424.758324,"created":"2025-03-24T09:58:40.145098","updated":"2025-03-24T09:58:40.145104","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ead5d0b-d8f4-447e-be12-fa265bc4177e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ead5d0b-d8f4-447e-be12-fa265bc4177e/pipeline.log\">pipeline</a>"]}]} -->