### PR TITLE
For S2I builds do not use shared cluster

### DIFF
--- a/test/test_nginx_imagestream_s2i.py
+++ b/test/test_nginx_imagestream_s2i.py
@@ -26,7 +26,7 @@ class TestNginxImagestreamS2I:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -42,9 +42,10 @@ class TestNginxImagestreamS2I:
             imagestream_file=f"imagestreams/nginx-{os_name}.json",
             image_name=IMAGE_NAME,
             app="https://github.com/sclorg/nginx-container.git",
-            context=f"examples/{new_version}/test-app"
+            context=f"examples/{new_version}/test-app",
+            service_name=self.template_name
         )
-        assert self.oc_api.template_deployed(name_in_template=self.template_name)
+        assert self.oc_api.is_template_deployed(name_in_template=self.template_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=self.template_name, expected_output="Test NGINX passed"
         )

--- a/test/test_nginx_local_example.py
+++ b/test/test_nginx_local_example.py
@@ -19,18 +19,18 @@ class TestNginxLocalEx:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
-    def test_python_ex_template_inside_cluster(self):
+    def test_nginx_ex_template_inside_cluster(self):
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app="test-app",
             context=".",
             service_name=self.template_name
         )
-        assert self.oc_api.template_deployed(name_in_template=self.template_name)
+        assert self.oc_api.is_template_deployed(name_in_template=self.template_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=self.template_name, expected_output="Test NGINX passed"
         )

--- a/test/test_nginx_remote_example.py
+++ b/test/test_nginx_remote_example.py
@@ -20,18 +20,18 @@ class TestNginxLocalEx:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
-    def test_python_ex_template_inside_cluster(self):
+    def test_nginx_ex_template_inside_cluster(self):
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app=f"https://github.com/sclorg/nginx-ex.git",
             context=".",
             service_name=self.template_name
         )
-        assert self.oc_api.template_deployed(name_in_template=self.template_name)
+        assert self.oc_api.is_s2i_pod_running(pod_name_prefix=self.template_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=self.template_name, expected_output="Welcome to your static nginx application on OpenShift"
         )

--- a/test/test_nginx_template_example_app.py
+++ b/test/test_nginx_template_example_app.py
@@ -22,12 +22,12 @@ OS = os.getenv("TARGET")
 class TestNginxDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nginx-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="nginx-testing", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
-    def test_python_template_inside_cluster(self):
+    def test_nginx_template_inside_cluster(self):
         if OS == "rhel10":
             pytest.skip("Skipping test for rhel10")
         service_name = "nginx-testing"
@@ -44,7 +44,7 @@ class TestNginxDeployTemplate:
                 f"NAME={service_name}"
             ]
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name, timeout=300)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Welcome to your static nginx application on OpenShift"
         )


### PR DESCRIPTION
For S2I builds do not use shared cluster
It has an issue with pulling image like ErrImagePull.

Needs more investigation.

<!-- issue-commentator = {"comment-id":"2775182573"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2775254617","data":[{"id":"86ef9838-70b4-4694-b1e9-53330750873c","name":"RHEL10 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":858.737407,"created":"2025-04-03T10:09:17.588677","updated":"2025-04-03T10:09:17.588683","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/86ef9838-70b4-4694-b1e9-53330750873c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/86ef9838-70b4-4694-b1e9-53330750873c/pipeline.log\">pipeline</a>"]},{"id":"06e1682e-722f-4243-bce8-48422aebab5b","name":"RHEL9 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1195.882867,"created":"2025-04-03T10:09:18.478563","updated":"2025-04-03T10:09:18.478568","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/06e1682e-722f-4243-bce8-48422aebab5b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/06e1682e-722f-4243-bce8-48422aebab5b/pipeline.log\">pipeline</a>"]},{"id":"9bcfa9ae-edb7-4f24-8693-ae39ece9edc6","name":"RHEL8 - OpenShift 4 - 1.24","runTime":1294.304035,"created":"2025-04-03T11:08:47.348304","updated":"2025-04-03T11:08:47.348310","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bcfa9ae-edb7-4f24-8693-ae39ece9edc6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bcfa9ae-edb7-4f24-8693-ae39ece9edc6/pipeline.log\">pipeline</a>"]},{"id":"289cb11c-5855-426a-82ed-63101a398b47","name":"RHEL10 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1203.643122,"created":"2025-04-03T10:09:42.391347","updated":"2025-04-03T10:09:42.391356","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/289cb11c-5855-426a-82ed-63101a398b47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/289cb11c-5855-426a-82ed-63101a398b47/pipeline.log\">pipeline</a>"]},{"id":"dc9c3133-bd4d-4f82-9110-fe019cf110bc","name":"RHEL9 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1498.836718,"created":"2025-04-03T10:09:07.637249","updated":"2025-04-03T10:09:07.637257","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc9c3133-bd4d-4f82-9110-fe019cf110bc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc9c3133-bd4d-4f82-9110-fe019cf110bc/pipeline.log\">pipeline</a>"]},{"id":"8977fb11-ced5-4189-9eba-10b233c5ad80","name":"RHEL9 - PyTest - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1495.153306,"created":"2025-04-03T10:09:09.720377","updated":"2025-04-03T10:09:09.720383","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8977fb11-ced5-4189-9eba-10b233c5ad80\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8977fb11-ced5-4189-9eba-10b233c5ad80/pipeline.log\">pipeline</a>"]},{"id":"1040f276-0c43-4e7b-8c75-edb9a05af169","name":"RHEL9 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1288.162781,"created":"2025-04-03T11:08:47.308506","updated":"2025-04-03T11:08:47.308512","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1040f276-0c43-4e7b-8c75-edb9a05af169\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1040f276-0c43-4e7b-8c75-edb9a05af169/pipeline.log\">pipeline</a>"]},{"id":"1eb22921-2053-4829-9265-a6233f61f9f9","name":"RHEL8 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1836.161071,"created":"2025-04-03T10:09:09.917391","updated":"2025-04-03T10:09:09.917397","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1eb22921-2053-4829-9265-a6233f61f9f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1eb22921-2053-4829-9265-a6233f61f9f9/pipeline.log\">pipeline</a>"]},{"id":"dae5721b-4c59-4215-9f06-cab0be564169","name":"RHEL8 - PyTest - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1890.18377,"created":"2025-04-03T10:09:08.461096","updated":"2025-04-03T10:09:08.461103","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dae5721b-4c59-4215-9f06-cab0be564169\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dae5721b-4c59-4215-9f06-cab0be564169/pipeline.log\">pipeline</a>"]},{"id":"78fe1d66-57c6-4417-8be5-08acf246bda0","name":"RHEL9 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1016.670688,"created":"2025-04-03T10:24:41.946049","updated":"2025-04-03T10:24:41.946058","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/78fe1d66-57c6-4417-8be5-08acf246bda0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/78fe1d66-57c6-4417-8be5-08acf246bda0/pipeline.log\">pipeline</a>"]},{"id":"76c0a654-1d23-426b-8767-7552e11ec309","name":"RHEL9 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":2587.754613,"created":"2025-04-03T10:09:09.178279","updated":"2025-04-03T10:09:09.178285","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/76c0a654-1d23-426b-8767-7552e11ec309\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/76c0a654-1d23-426b-8767-7552e11ec309/pipeline.log\">pipeline</a>"]},{"id":"2f1c0005-52b3-45f6-9556-7f3da6ebe859","name":"RHEL8 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":2598.174524,"created":"2025-04-03T10:09:28.905491","updated":"2025-04-03T10:09:28.905497","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f1c0005-52b3-45f6-9556-7f3da6ebe859\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f1c0005-52b3-45f6-9556-7f3da6ebe859/pipeline.log\">pipeline</a>"]},{"id":"ee367515-cae0-4cc4-baa3-a71a4ae68472","name":"RHEL8 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1471.273029,"created":"2025-04-03T10:30:09.207011","updated":"2025-04-03T10:30:09.207016","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee367515-cae0-4cc4-baa3-a71a4ae68472\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee367515-cae0-4cc4-baa3-a71a4ae68472/pipeline.log\">pipeline</a>"]},{"id":"45304d17-717a-4cf4-b604-733a4569965e","name":"RHEL9 - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1491.546247,"created":"2025-04-03T10:30:36.599452","updated":"2025-04-03T10:30:36.599457","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45304d17-717a-4cf4-b604-733a4569965e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45304d17-717a-4cf4-b604-733a4569965e/pipeline.log\">pipeline</a>"]},{"id":"f37a70f2-54df-4472-9303-f6d55dcbc997","name":"RHEL8 - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":2910.238541,"created":"2025-04-03T10:09:34.444883","updated":"2025-04-03T10:09:34.444889","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f37a70f2-54df-4472-9303-f6d55dcbc997\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f37a70f2-54df-4472-9303-f6d55dcbc997/pipeline.log\">pipeline</a>"]},{"id":"58e7828b-dbbe-4cf0-a4ac-fd9978b535e3","name":"RHEL9 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":3062.678932,"created":"2025-04-03T10:09:28.843092","updated":"2025-04-03T10:09:28.843099","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58e7828b-dbbe-4cf0-a4ac-fd9978b535e3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58e7828b-dbbe-4cf0-a4ac-fd9978b535e3/pipeline.log\">pipeline</a>"]}]} -->