### PR TITLE
Do not test curl connection

### DIFF
--- a/test/test_shared_helm_nginx_template.py
+++ b/test/test_shared_helm_nginx_template.py
@@ -41,30 +41,6 @@ class TestHelmNginxTemplate:
     def teardown_method(self):
         self.hc_api.delete_project()
 
-    def test_curl_connection(self):
-        if self.hc_api.shared_cluster:
-            pytest.skip("Do NOT test on shared cluster")
-        new_version = VERSION
-        if "micro" in VERSION:
-            new_version = VERSION.replace("-micro", "")
-        self.hc_api.package_name = "redhat-nginx-imagestreams"
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "redhat-nginx-template"
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation(
-            values={
-                "nginx_version": f"{new_version}{TAG}",
-                "namespace": self.hc_api.namespace
-            }
-        )
-        expected_str = "Welcome to your static nginx application on OpenShift"
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="nginx-example")
-        assert self.hc_api.test_helm_curl_output(
-            route_name="nginx-example",
-            expected_str=expected_str
-        )
-
     def test_helm_connection(self):
         if OS == "rhel10":
             pytest.skip("Skipping test for rhel10")


### PR DESCRIPTION
Do not test curl connection.

It does not make sense. We used 'helm test' that is enought.

<!-- issue-commentator = {"comment-id":"2853786228"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2853805781","data":[{"id":"a1605122-330e-4f27-be96-c65fca3cd266","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":339.907115,"created":"2025-05-06T08:59:50.010452","updated":"2025-05-06T08:59:50.010458","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1605122-330e-4f27-be96-c65fca3cd266\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1605122-330e-4f27-be96-c65fca3cd266/pipeline.log\">pipeline</a>"]},{"id":"eb743617-b55f-4801-94c2-7eb670e441f5","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":395.175695,"created":"2025-05-06T08:59:31.148782","updated":"2025-05-06T08:59:31.148788","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/eb743617-b55f-4801-94c2-7eb670e441f5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/eb743617-b55f-4801-94c2-7eb670e441f5/pipeline.log\">pipeline</a>"]},{"id":"416ed021-935c-4f93-9776-30a3ef100e7c","name":"CentOS Stream 9 - 1.26","status":"complete","outcome":"passed","runTime":404.758496,"created":"2025-05-06T08:59:41.471843","updated":"2025-05-06T08:59:41.471851","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/416ed021-935c-4f93-9776-30a3ef100e7c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/416ed021-935c-4f93-9776-30a3ef100e7c/pipeline.log\">pipeline</a>"]},{"id":"4303a8d2-5b3d-4f91-92fa-ddbcda0a9482","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":466.50297,"created":"2025-05-06T08:59:41.012038","updated":"2025-05-06T08:59:41.012044","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4303a8d2-5b3d-4f91-92fa-ddbcda0a9482\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4303a8d2-5b3d-4f91-92fa-ddbcda0a9482/pipeline.log\">pipeline</a>"]},{"id":"42fd5e81-a2cf-4907-83a5-8c0c3b026a42","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":506.832677,"created":"2025-05-06T08:59:41.496298","updated":"2025-05-06T08:59:41.496304","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/42fd5e81-a2cf-4907-83a5-8c0c3b026a42\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/42fd5e81-a2cf-4907-83a5-8c0c3b026a42/pipeline.log\">pipeline</a>"]},{"id":"a04be854-4e9c-4c6c-bd0e-cc00b336995f","name":"RHEL10 - 1.26","status":"complete","outcome":"passed","runTime":911.9584,"created":"2025-05-06T08:59:48.315567","updated":"2025-05-06T08:59:48.315574","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a04be854-4e9c-4c6c-bd0e-cc00b336995f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a04be854-4e9c-4c6c-bd0e-cc00b336995f/pipeline.log\">pipeline</a>"]},{"id":"5a20647f-0f79-448d-aa85-cf72d3b4bcac","name":"RHEL9 - Unsubscribed host - 1.26","status":"complete","outcome":"passed","runTime":958.584614,"created":"2025-05-06T08:59:32.466382","updated":"2025-05-06T08:59:32.466391","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a20647f-0f79-448d-aa85-cf72d3b4bcac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a20647f-0f79-448d-aa85-cf72d3b4bcac/pipeline.log\">pipeline</a>"]},{"id":"ca0a37e0-0da2-455e-aff8-983ccc131702","name":"RHEL9 - Unsubscribed host - 1.20","runTime":921.323569,"created":"2025-05-06T10:08:45.428176","updated":"2025-05-06T10:08:45.428183","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ca0a37e0-0da2-455e-aff8-983ccc131702\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ca0a37e0-0da2-455e-aff8-983ccc131702/pipeline.log\">pipeline</a>"]},{"id":"8c95ca6f-2c3d-41f4-b68b-2e21058c6c3c","name":"RHEL9 - Unsubscribed host - 1.24","status":"complete","outcome":"passed","runTime":1081.46377,"created":"2025-05-06T08:59:31.941415","updated":"2025-05-06T08:59:31.941427","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c95ca6f-2c3d-41f4-b68b-2e21058c6c3c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c95ca6f-2c3d-41f4-b68b-2e21058c6c3c/pipeline.log\">pipeline</a>"]},{"id":"525547c6-3409-4d04-a266-d5a71e7f389e","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":1066.99277,"created":"2025-05-06T08:59:33.526695","updated":"2025-05-06T08:59:33.526701","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/525547c6-3409-4d04-a266-d5a71e7f389e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/525547c6-3409-4d04-a266-d5a71e7f389e/pipeline.log\">pipeline</a>"]},{"id":"531f23d0-6af1-4e26-a678-97cf40bc4615","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":1078.900634,"created":"2025-05-06T08:59:31.418104","updated":"2025-05-06T08:59:31.418129","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/531f23d0-6af1-4e26-a678-97cf40bc4615\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/531f23d0-6af1-4e26-a678-97cf40bc4615/pipeline.log\">pipeline</a>"]},{"id":"4ff5840a-acf1-4690-8539-436be6d36713","name":"RHEL9 - 1.26","status":"complete","outcome":"passed","runTime":1082.173801,"created":"2025-05-06T08:59:47.775449","updated":"2025-05-06T08:59:47.775454","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ff5840a-acf1-4690-8539-436be6d36713\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ff5840a-acf1-4690-8539-436be6d36713/pipeline.log\">pipeline</a>"]},{"id":"4dbc3229-b9f7-4e32-bbf2-0a99b28d97c8","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":1087.011918,"created":"2025-05-06T08:59:31.688559","updated":"2025-05-06T08:59:31.688568","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4dbc3229-b9f7-4e32-bbf2-0a99b28d97c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4dbc3229-b9f7-4e32-bbf2-0a99b28d97c8/pipeline.log\">pipeline</a>"]},{"id":"8393a17f-1669-4dc6-9e74-d6b405a4b967","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":1112.255716,"created":"2025-05-06T08:59:33.409590","updated":"2025-05-06T08:59:33.409597","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8393a17f-1669-4dc6-9e74-d6b405a4b967\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8393a17f-1669-4dc6-9e74-d6b405a4b967/pipeline.log\">pipeline</a>"]},{"id":"8d1d79a9-2654-43cb-9cb7-3dbb8c6e2da6","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":1133.037757,"created":"2025-05-06T08:59:39.357761","updated":"2025-05-06T08:59:39.357787","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d1d79a9-2654-43cb-9cb7-3dbb8c6e2da6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d1d79a9-2654-43cb-9cb7-3dbb8c6e2da6/pipeline.log\">pipeline</a>"]},{"id":"7fe11be2-9c15-4048-9e8d-e97159e8b223","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":1111.227767,"created":"2025-05-06T09:00:05.824817","updated":"2025-05-06T09:00:05.824823","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7fe11be2-9c15-4048-9e8d-e97159e8b223\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7fe11be2-9c15-4048-9e8d-e97159e8b223/pipeline.log\">pipeline</a>"]},{"id":"990d8aa4-5d98-4447-8c81-5520d1f6ab29","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":1232.332464,"created":"2025-05-06T08:59:32.507099","updated":"2025-05-06T08:59:32.507106","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/990d8aa4-5d98-4447-8c81-5520d1f6ab29\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/990d8aa4-5d98-4447-8c81-5520d1f6ab29/pipeline.log\">pipeline</a>"]},{"id":"5e82364a-b128-4168-aab8-fba5c5a36b55","name":"RHEL8 - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1335.046,"created":"2025-05-06T08:59:52.244538","updated":"2025-05-06T08:59:52.244545","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e82364a-b128-4168-aab8-fba5c5a36b55\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e82364a-b128-4168-aab8-fba5c5a36b55/pipeline.log\">pipeline</a>"]},{"id":"b97f72c3-104c-49e8-987b-3685eeded2ac","name":"RHEL9 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":940.079218,"created":"2025-05-06T09:06:48.390029","updated":"2025-05-06T09:06:48.390035","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b97f72c3-104c-49e8-987b-3685eeded2ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b97f72c3-104c-49e8-987b-3685eeded2ac/pipeline.log\">pipeline</a>"]},{"id":"565888e4-9901-4a78-88db-56172ab3a8ea","name":"RHEL9 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1419.055311,"created":"2025-05-06T08:59:54.342384","updated":"2025-05-06T08:59:54.342391","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/565888e4-9901-4a78-88db-56172ab3a8ea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/565888e4-9901-4a78-88db-56172ab3a8ea/pipeline.log\">pipeline</a>"]},{"id":"2a90085f-0aa7-4335-a67f-6abe9aa78800","name":"RHEL9 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1424.857431,"created":"2025-05-06T08:59:57.514565","updated":"2025-05-06T08:59:57.514571","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a90085f-0aa7-4335-a67f-6abe9aa78800\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a90085f-0aa7-4335-a67f-6abe9aa78800/pipeline.log\">pipeline</a>"]},{"id":"7a882ec2-63a8-42cf-8587-5cdc3e2ad876","name":"RHEL9 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1202.944374,"created":"2025-05-06T09:06:09.583756","updated":"2025-05-06T09:06:09.583761","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a882ec2-63a8-42cf-8587-5cdc3e2ad876\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a882ec2-63a8-42cf-8587-5cdc3e2ad876/pipeline.log\">pipeline</a>"]},{"id":"2f697c52-5c30-4082-a36d-98be33796ce1","name":"RHEL8 - PyTest - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1295.215023,"created":"2025-05-06T09:08:04.347273","updated":"2025-05-06T09:08:04.347279","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f697c52-5c30-4082-a36d-98be33796ce1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f697c52-5c30-4082-a36d-98be33796ce1/pipeline.log\">pipeline</a>"]},{"id":"74c1b4c0-5a96-4dc7-8898-dc61cfa35c8a","name":"RHEL9 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1299.359719,"created":"2025-05-06T09:08:29.061536","updated":"2025-05-06T09:08:29.061542","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74c1b4c0-5a96-4dc7-8898-dc61cfa35c8a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74c1b4c0-5a96-4dc7-8898-dc61cfa35c8a/pipeline.log\">pipeline</a>"]},{"id":"94db6995-decc-4ddf-95aa-e3f6fccc9094","name":"RHEL8 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1391.644567,"created":"2025-05-06T09:07:41.942999","updated":"2025-05-06T09:07:41.943004","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/94db6995-decc-4ddf-95aa-e3f6fccc9094\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/94db6995-decc-4ddf-95aa-e3f6fccc9094/pipeline.log\">pipeline</a>"]},{"id":"80725b40-5a0b-4cfa-b261-9d89c1d8a486","name":"RHEL10 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":793.036235,"created":"2025-05-06T09:18:28.142397","updated":"2025-05-06T09:18:28.142403","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/80725b40-5a0b-4cfa-b261-9d89c1d8a486\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/80725b40-5a0b-4cfa-b261-9d89c1d8a486/pipeline.log\">pipeline</a>"]},{"id":"f55879a2-158c-4188-9dbb-ee6c28b3d589","name":"RHEL10 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1091.073492,"created":"2025-05-06T09:15:58.112403","updated":"2025-05-06T09:15:58.112413","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f55879a2-158c-4188-9dbb-ee6c28b3d589\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f55879a2-158c-4188-9dbb-ee6c28b3d589/pipeline.log\">pipeline</a>"]},{"id":"67285319-397f-4d77-a138-fa6a08e2c6c4","name":"RHEL8 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1320.53133,"created":"2025-05-06T09:16:02.171271","updated":"2025-05-06T09:16:02.171277","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67285319-397f-4d77-a138-fa6a08e2c6c4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67285319-397f-4d77-a138-fa6a08e2c6c4/pipeline.log\">pipeline</a>"]},{"id":"9494e7cd-52b1-4d8d-88a1-ddeb120e8471","name":"RHEL8 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1267.691571,"created":"2025-05-06T09:18:41.978974","updated":"2025-05-06T09:18:41.978983","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9494e7cd-52b1-4d8d-88a1-ddeb120e8471\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9494e7cd-52b1-4d8d-88a1-ddeb120e8471/pipeline.log\">pipeline</a>"]},{"id":"24bd4dea-b045-4cb2-a372-940b65ff6020","name":"RHEL9 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1300.098643,"created":"2025-05-06T09:18:21.622329","updated":"2025-05-06T09:18:21.622335","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/24bd4dea-b045-4cb2-a372-940b65ff6020\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/24bd4dea-b045-4cb2-a372-940b65ff6020/pipeline.log\">pipeline</a>"]},{"id":"30a9bfe5-6146-4aeb-8763-31ac20f3bf5e","name":"RHEL9 - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1368.091293,"created":"2025-05-06T09:18:35.547601","updated":"2025-05-06T09:18:35.547607","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30a9bfe5-6146-4aeb-8763-31ac20f3bf5e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30a9bfe5-6146-4aeb-8763-31ac20f3bf5e/pipeline.log\">pipeline</a>"]},{"id":"fc5ef36a-528b-499d-b8dc-2072030e165e","name":"RHEL9 - PyTest - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1402.917803,"created":"2025-05-06T09:18:08.493166","updated":"2025-05-06T09:18:08.493172","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc5ef36a-528b-499d-b8dc-2072030e165e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc5ef36a-528b-499d-b8dc-2072030e165e/pipeline.log\">pipeline</a>"]},{"id":"02c8f719-9f5b-457d-a265-5ff59b9b8a66","name":"RHEL8 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1392.744926,"created":"2025-05-06T09:18:02.548668","updated":"2025-05-06T09:18:02.548676","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02c8f719-9f5b-457d-a265-5ff59b9b8a66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02c8f719-9f5b-457d-a265-5ff59b9b8a66/pipeline.log\">pipeline</a>"]}]} -->