### PR TITLE
Fix reg expression for getting rhel name from 'rhel10'

### DIFF
--- a/test/test-lib-nginx.sh
+++ b/test/test-lib-nginx.sh
@@ -29,7 +29,7 @@ function test_nginx_imagestream() {
       return
     fi
   fi
-  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/nginx-${OS%[0-9]*}.json" "${IMAGE_NAME}" \
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/nginx-${OS//[0-9]/}.json" "${IMAGE_NAME}" \
                               "https://github.com/sclorg/nginx-container.git" \
                               "examples/${VERSION}/test-app" \
                               "Test NGINX passed"


### PR DESCRIPTION
Fix reg expression for getting rhel name from 'rhel10'

The new expresssion removes all digits.


