### PR TITLE
Allow testing nginx-container on shared_cluster

### DIFF
--- a/test/test_nginx_imagestream_s2i.py
+++ b/test/test_nginx_imagestream_s2i.py
@@ -22,7 +22,7 @@ class TestNginxImagestreamS2I:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_nginx_local_example.py
+++ b/test/test_nginx_local_example.py
@@ -19,7 +19,7 @@ class TestNginxLocalEx:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_nginx_remote_example.py
+++ b/test/test_nginx_remote_example.py
@@ -20,7 +20,7 @@ class TestNginxLocalEx:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_nginx_template_example_app.py
+++ b/test/test_nginx_template_example_app.py
@@ -22,7 +22,7 @@ OS = os.getenv("TARGET")
 class TestNginxDeployTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nginx-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="nginx-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_shared_helm_nginx_imagestreams.py
+++ b/test/test_shared_helm_nginx_imagestreams.py
@@ -20,7 +20,7 @@ class TestHelmRHELNginxImageStreams:
     def setup_method(self):
         package_name = "redhat-nginx-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"


### PR DESCRIPTION
<!-- issue-commentator = {"comment-id":"2996156322"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2996208207","data":[{"id":"be35466c-0781-46f1-824b-d415b8dca758","name":"RHEL9 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":943.171121,"created":"2025-06-23T11:45:08.296269","updated":"2025-06-23T11:45:08.296275","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/be35466c-0781-46f1-824b-d415b8dca758\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/be35466c-0781-46f1-824b-d415b8dca758/pipeline.log\">pipeline</a>"]},{"id":"bbed3126-832c-4cfc-b6ba-5ce5a949bf91","name":"RHEL10 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1009.602935,"created":"2025-06-23T11:44:57.689703","updated":"2025-06-23T11:44:57.689708","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bbed3126-832c-4cfc-b6ba-5ce5a949bf91\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bbed3126-832c-4cfc-b6ba-5ce5a949bf91/pipeline.log\">pipeline</a>"]},{"id":"dfc3b8af-1fbd-4791-a468-15e444adc272","name":"RHEL8 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1237.553081,"created":"2025-06-23T11:45:01.709921","updated":"2025-06-23T11:45:01.709926","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dfc3b8af-1fbd-4791-a468-15e444adc272\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dfc3b8af-1fbd-4791-a468-15e444adc272/pipeline.log\">pipeline</a>"]},{"id":"95f80c14-edc3-4c79-ac28-38d4e2b3f2d0","name":"RHEL8 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1316.199795,"created":"2025-06-23T11:44:59.255808","updated":"2025-06-23T11:44:59.255814","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/95f80c14-edc3-4c79-ac28-38d4e2b3f2d0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/95f80c14-edc3-4c79-ac28-38d4e2b3f2d0/pipeline.log\">pipeline</a>"]},{"id":"0cdd8f99-8167-4814-b25b-e37d1b83f366","name":"RHEL8 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1293.088203,"created":"2025-06-23T11:45:04.783665","updated":"2025-06-23T11:45:04.783671","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0cdd8f99-8167-4814-b25b-e37d1b83f366\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0cdd8f99-8167-4814-b25b-e37d1b83f366/pipeline.log\">pipeline</a>"]},{"id":"75e92036-c64a-4406-b7f3-e765e7d925a6","name":"RHEL9 - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1411.415827,"created":"2025-06-23T11:44:57.532802","updated":"2025-06-23T11:44:57.532807","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75e92036-c64a-4406-b7f3-e765e7d925a6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75e92036-c64a-4406-b7f3-e765e7d925a6/pipeline.log\">pipeline</a>"]},{"id":"5d7398ef-01b6-4a38-9044-bf23f3861979","name":"RHEL9 - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1420.699253,"created":"2025-06-23T11:44:57.609279","updated":"2025-06-23T11:44:57.609286","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d7398ef-01b6-4a38-9044-bf23f3861979\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d7398ef-01b6-4a38-9044-bf23f3861979/pipeline.log\">pipeline</a>"]},{"id":"ce527426-67bf-4486-92b8-323bf23023d5","name":"RHEL8 - OpenShift 4 - 1.22-micro","status":"complete","outcome":"passed","runTime":1357.946296,"created":"2025-06-23T11:45:04.541244","updated":"2025-06-23T11:45:04.541249","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce527426-67bf-4486-92b8-323bf23023d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce527426-67bf-4486-92b8-323bf23023d5/pipeline.log\">pipeline</a>"]},{"id":"27c29550-f7c0-484e-8a69-a957b1e377bd","name":"RHEL9 - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":1402.613362,"created":"2025-06-23T11:45:13.273580","updated":"2025-06-23T11:45:13.273587","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27c29550-f7c0-484e-8a69-a957b1e377bd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27c29550-f7c0-484e-8a69-a957b1e377bd/pipeline.log\">pipeline</a>"]},{"id":"a3400491-174b-4f05-8fd6-b6ef264278c7","name":"RHEL8 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1362.08228,"created":"2025-06-23T11:45:33.154824","updated":"2025-06-23T11:45:33.154830","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a3400491-174b-4f05-8fd6-b6ef264278c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a3400491-174b-4f05-8fd6-b6ef264278c7/pipeline.log\">pipeline</a>"]},{"id":"89377051-e689-46cd-9e2d-e9d31d1d1835","name":"RHEL9 - PyTest - OpenShift 4 - 1.24","status":"complete","outcome":"passed","runTime":1476.617186,"created":"2025-06-23T11:45:26.528712","updated":"2025-06-23T11:45:26.528718","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/89377051-e689-46cd-9e2d-e9d31d1d1835\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/89377051-e689-46cd-9e2d-e9d31d1d1835/pipeline.log\">pipeline</a>"]},{"id":"4077cfc0-8872-4079-a66f-4d4d52276d0c","name":"RHEL10 - PyTest - OpenShift 4 - 1.26","status":"complete","outcome":"passed","runTime":652.878571,"created":"2025-06-23T12:07:23.588742","updated":"2025-06-23T12:07:23.588748","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4077cfc0-8872-4079-a66f-4d4d52276d0c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4077cfc0-8872-4079-a66f-4d4d52276d0c/pipeline.log\">pipeline</a>"]},{"id":"b817e70d-d495-4fbe-a2bb-1756cbff30cd","name":"RHEL9 - PyTest - OpenShift 4 - 1.20","status":"complete","outcome":"passed","runTime":1306.519265,"created":"2025-06-23T12:01:45.258618","updated":"2025-06-23T12:01:45.258625","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b817e70d-d495-4fbe-a2bb-1756cbff30cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b817e70d-d495-4fbe-a2bb-1756cbff30cd/pipeline.log\">pipeline</a>"]},{"id":"852cda6e-f983-4ec5-939d-ae0b199de25c","name":"RHEL9 - PyTest - OpenShift 4 - 1.22","status":"complete","outcome":"passed","runTime":1346.385486,"created":"2025-06-23T12:03:33.389841","updated":"2025-06-23T12:03:33.389847","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/852cda6e-f983-4ec5-939d-ae0b199de25c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/852cda6e-f983-4ec5-939d-ae0b199de25c/pipeline.log\">pipeline</a>"]},{"id":"f6e6d94f-ddd6-4f4b-80f8-365ec254d17d","name":"RHEL8 - PyTest - OpenShift 4 - 1.22-micro","runTime":1212.786247,"created":"2025-06-23T12:07:25.773810","updated":"2025-06-23T12:07:25.773815","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6e6d94f-ddd6-4f4b-80f8-365ec254d17d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6e6d94f-ddd6-4f4b-80f8-365ec254d17d/pipeline.log\">pipeline</a>"]}]} -->