### PR TITLE
Add GitHub Action for running ContainerPytest suite

### DIFF
--- a/.github/workflows/container-pytest.yml
+++ b/.github/workflows/container-pytest.yml
@@ -1,0 +1,30 @@
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  container-tests:
+    name: "Container PyTest: ${{ matrix.version }} - ${{ matrix.os_test }}"
+    runs-on: ubuntu-latest
+    concurrency:
+      group: container-pytest-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ "1.20", "1.22", "1.22-micro", "1.24", "1.26" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s", "rhel9-unsubscribed" ]
+        test_case: [ "container-pytest" ]
+
+    if: |
+      github.event.issue.pull_request
+      && (contains(github.event.comment.body, '[test-pytest]') || contains(github.event.comment.body, '[test-all]'))
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    steps:
+      - uses: sclorg/tfaga-wrapper@main
+        with:
+          os_test: ${{ matrix.os_test }}
+          version: ${{ matrix.version }}
+          test_case: ${{ matrix.test_case }}
+          public_api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          private_api_key: ${{ secrets.TF_INTERNAL_API_KEY }}

--- a/1.20/Dockerfile.rhel9
+++ b/1.20/Dockerfile.rhel9
@@ -38,7 +38,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_LOG_PATH=/var/log/nginx \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
-RUN INSTALL_PKGS="nss_wrapper bind9.18-utils gettext hostname nginx nginx-all-modules" && \
+RUN INSTALL_PKGS="nss_wrapper bind-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \

--- a/1.22/Dockerfile.rhel9
+++ b/1.22/Dockerfile.rhel9
@@ -39,7 +39,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper-libs bind9.18-utils gettext hostname nginx nginx-all-modules" && \
+    INSTALL_PKGS="nss_wrapper-libs bind-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \

--- a/1.24/Dockerfile.rhel9
+++ b/1.24/Dockerfile.rhel9
@@ -39,7 +39,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper-libs bind9.18-utils gettext hostname nginx nginx-all-modules" && \
+    INSTALL_PKGS="nss_wrapper-libs bind-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \

--- a/1.26/Dockerfile.rhel9
+++ b/1.26/Dockerfile.rhel9
@@ -39,7 +39,7 @@ ENV NGINX_CONFIGURATION_PATH=${APP_ROOT}/etc/nginx.d \
     NGINX_PERL_MODULE_PATH=${APP_ROOT}/etc/perl
 
 RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nss_wrapper-libs bind9.18-utils gettext hostname nginx nginx-all-modules" && \
+    INSTALL_PKGS="nss_wrapper-libs bind-utils gettext hostname nginx nginx-all-modules" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     nginx -v 2>&1 | grep -qe "nginx/$NGINX_VERSION\." && echo "Found VERSION $NGINX_VERSION" && \


### PR DESCRIPTION
Add GitHub Action for running ContainerPytest suite

to nginx-container

<!-- issue-commentator = {"comment-id":"3249141858"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3249165516","data":[{"id":"e0d73f0c-d959-4507-866b-51d4e036a676","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":349.731765,"created":"2025-09-03T13:25:14.429256","updated":"2025-09-03T13:25:14.429265","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e0d73f0c-d959-4507-866b-51d4e036a676\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e0d73f0c-d959-4507-866b-51d4e036a676/pipeline.log\">pipeline</a>"]},{"id":"79f612b3-8b15-48c7-a01f-1fd8a3dde55a","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":333.813277,"created":"2025-09-03T13:25:22.032480","updated":"2025-09-03T13:25:22.032486","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/79f612b3-8b15-48c7-a01f-1fd8a3dde55a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/79f612b3-8b15-48c7-a01f-1fd8a3dde55a/pipeline.log\">pipeline</a>"]},{"id":"01f8b90f-18bf-4299-b2bf-45f7309562e9","name":"CentOS Stream 9 - 1.26","status":"complete","outcome":"passed","runTime":390.232523,"created":"2025-09-03T13:25:14.433252","updated":"2025-09-03T13:25:14.433260","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/01f8b90f-18bf-4299-b2bf-45f7309562e9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/01f8b90f-18bf-4299-b2bf-45f7309562e9/pipeline.log\">pipeline</a>"]},{"id":"4a98d3ea-6049-4435-a196-ed1f33448e42","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":376.292218,"created":"2025-09-03T13:25:14.424651","updated":"2025-09-03T13:25:14.424659","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4a98d3ea-6049-4435-a196-ed1f33448e42\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4a98d3ea-6049-4435-a196-ed1f33448e42/pipeline.log\">pipeline</a>"]},{"id":"6685dce3-cabc-4d3b-b1a8-370d0de257eb","name":"RHEL10 - 1.26","status":"complete","outcome":"passed","runTime":717.729055,"created":"2025-09-03T13:25:14.610331","updated":"2025-09-03T13:25:14.610337","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6685dce3-cabc-4d3b-b1a8-370d0de257eb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6685dce3-cabc-4d3b-b1a8-370d0de257eb/pipeline.log\">pipeline</a>"]},{"id":"a4728794-4e4c-4ccc-a21e-4bc6fea37a5d","name":"RHEL9 - Unsubscribed host - 1.24","status":"complete","outcome":"error","runTime":830.883527,"created":"2025-09-03T12:56:20.551108","updated":"2025-09-03T12:56:20.551148","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4728794-4e4c-4ccc-a21e-4bc6fea37a5d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4728794-4e4c-4ccc-a21e-4bc6fea37a5d/pipeline.log\">pipeline</a>"]},{"id":"3195c41f-b2f7-469f-a581-31fe52559592","name":"RHEL9 - Unsubscribed host - 1.26","status":"complete","outcome":"passed","runTime":893.775346,"created":"2025-09-03T13:25:14.237220","updated":"2025-09-03T13:25:14.237228","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3195c41f-b2f7-469f-a581-31fe52559592\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3195c41f-b2f7-469f-a581-31fe52559592/pipeline.log\">pipeline</a>"]},{"id":"f1e510e2-2e12-426a-991e-23e850a60a4f","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":891.057333,"created":"2025-09-03T13:25:37.059472","updated":"2025-09-03T13:25:37.059478","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1e510e2-2e12-426a-991e-23e850a60a4f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1e510e2-2e12-426a-991e-23e850a60a4f/pipeline.log\">pipeline</a>"]},{"id":"ac777eea-1a85-4145-8dc4-0fdd0af90ee3","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":862.495974,"created":"2025-09-03T13:25:17.292223","updated":"2025-09-03T13:25:17.292228","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac777eea-1a85-4145-8dc4-0fdd0af90ee3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac777eea-1a85-4145-8dc4-0fdd0af90ee3/pipeline.log\">pipeline</a>"]},{"id":"7002ca5a-e465-435f-bf16-1718923ff9dc","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"error","runTime":904.415017,"created":"2025-09-03T12:56:41.507672","updated":"2025-09-03T12:56:41.507678","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7002ca5a-e465-435f-bf16-1718923ff9dc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7002ca5a-e465-435f-bf16-1718923ff9dc/pipeline.log\">pipeline</a>"]},{"id":"e5004d90-2b7c-4760-b933-b906a3dc2f47","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":872.746657,"created":"2025-09-03T13:25:15.620824","updated":"2025-09-03T13:25:15.620831","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5004d90-2b7c-4760-b933-b906a3dc2f47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5004d90-2b7c-4760-b933-b906a3dc2f47/pipeline.log\">pipeline</a>"]},{"id":"b64dc771-0b4e-4987-a2a5-cf0d369b06a4","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":1038.317197,"created":"2025-09-03T13:25:16.999746","updated":"2025-09-03T13:25:16.999753","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b64dc771-0b4e-4987-a2a5-cf0d369b06a4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b64dc771-0b4e-4987-a2a5-cf0d369b06a4/pipeline.log\">pipeline</a>"]},{"id":"759703b7-ba3e-40a9-8a2a-2465329d9de1","name":"RHEL9 - 1.20","runTime":1019.570629,"created":"2025-09-03T13:25:35.976152","updated":"2025-09-03T13:25:35.976158","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/759703b7-ba3e-40a9-8a2a-2465329d9de1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/759703b7-ba3e-40a9-8a2a-2465329d9de1/pipeline.log\">pipeline</a>"]},{"id":"f2541f18-1c87-4269-a505-a7d9e7d92071","name":"RHEL9 - 1.26","status":"complete","outcome":"passed","runTime":988.733729,"created":"2025-09-03T12:56:24.138781","updated":"2025-09-03T12:56:24.138787","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2541f18-1c87-4269-a505-a7d9e7d92071\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2541f18-1c87-4269-a505-a7d9e7d92071/pipeline.log\">pipeline</a>"]},{"id":"753f4e26-cf62-493b-8086-d6ac7c74a72a","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":878.110131,"created":"2025-09-03T13:25:30.079904","updated":"2025-09-03T13:25:30.079910","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/753f4e26-cf62-493b-8086-d6ac7c74a72a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/753f4e26-cf62-493b-8086-d6ac7c74a72a/pipeline.log\">pipeline</a>"]},{"id":"02e8c9c8-3689-4d9f-942a-c7e55835d9e9","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":1008.471514,"created":"2025-09-03T13:25:14.504352","updated":"2025-09-03T13:25:14.504359","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02e8c9c8-3689-4d9f-942a-c7e55835d9e9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02e8c9c8-3689-4d9f-942a-c7e55835d9e9/pipeline.log\">pipeline</a>"]},{"id":"54f85a17-4fa3-463f-85f7-1b00e3931338","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":363.137168,"created":"2025-09-03T13:25:21.331180","updated":"2025-09-03T13:25:21.331186","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/54f85a17-4fa3-463f-85f7-1b00e3931338\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/54f85a17-4fa3-463f-85f7-1b00e3931338/pipeline.log\">pipeline</a>"]}]} -->