### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/1.26/Dockerfile.rhel10
+++ b/1.26/Dockerfile.rhel10
@@ -24,7 +24,6 @@ LABEL summary="${SUMMARY}" \
       io.openshift.tags="builder,${NAME},${NAME}-${NGINX_SHORT_VER}" \
       com.redhat.component="${NAME}-${NGINX_SHORT_VER}-container" \
       name="ubi10/nginx-${NGINX_SHORT_VER}" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/${NAME}-container" \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279228069"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279287936","data":[{"id":"71ed3e0f-1405-485e-bf5e-6b0c65b53195","name":"Fedora - 1.26","status":"complete","outcome":"passed","runTime":440.468827,"created":"2025-09-12T09:58:24.105642","updated":"2025-09-12T09:58:24.105651","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/71ed3e0f-1405-485e-bf5e-6b0c65b53195\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/71ed3e0f-1405-485e-bf5e-6b0c65b53195/pipeline.log\">pipeline</a>"]},{"id":"4e2ea734-727c-4877-96fd-61e693ac82e8","name":"CentOS Stream 9 - 1.26","status":"complete","outcome":"passed","runTime":579.643784,"created":"2025-09-12T10:04:06.486740","updated":"2025-09-12T10:04:06.486763","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4e2ea734-727c-4877-96fd-61e693ac82e8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4e2ea734-727c-4877-96fd-61e693ac82e8/pipeline.log\">pipeline</a>"]},{"id":"185c8b31-3b64-4bae-ba28-6aab5b2d4c80","name":"RHEL8 - 1.22-micro","status":"complete","outcome":"passed","runTime":1014.035985,"created":"2025-09-12T10:03:53.208719","updated":"2025-09-12T10:03:53.208726","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/185c8b31-3b64-4bae-ba28-6aab5b2d4c80\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/185c8b31-3b64-4bae-ba28-6aab5b2d4c80/pipeline.log\">pipeline</a>"]},{"id":"05d7babc-f95d-4469-997c-12d454512011","name":"RHEL9 - 1.24","status":"complete","outcome":"passed","runTime":1093.661738,"created":"2025-09-12T10:25:56.880841","updated":"2025-09-12T10:25:56.880848","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/05d7babc-f95d-4469-997c-12d454512011\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/05d7babc-f95d-4469-997c-12d454512011/pipeline.log\">pipeline</a>"]},{"id":"0105c2a3-bdb7-4511-a201-e1a812067a27","name":"RHEL9 - Unsubscribed host - 1.24","runTime":1015.853797,"created":"2025-09-12T10:37:03.181550","updated":"2025-09-12T10:37:03.181557","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0105c2a3-bdb7-4511-a201-e1a812067a27\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0105c2a3-bdb7-4511-a201-e1a812067a27/pipeline.log\">pipeline</a>"]},{"id":"5511b1a3-7ead-46e1-bdab-11a72b4005ec","name":"CentOS Stream 9 - 1.22-micro","status":"complete","outcome":"passed","runTime":575.230018,"created":"2025-09-12T09:55:18.420635","updated":"2025-09-12T09:55:18.420642","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5511b1a3-7ead-46e1-bdab-11a72b4005ec\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5511b1a3-7ead-46e1-bdab-11a72b4005ec/pipeline.log\">pipeline</a>"]},{"id":"1599400f-8deb-4e1c-8f00-36877e085317","name":"RHEL9 - 1.20","status":"complete","outcome":"passed","runTime":1172.589114,"created":"2025-09-12T10:19:45.266633","updated":"2025-09-12T10:19:45.266639","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1599400f-8deb-4e1c-8f00-36877e085317\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1599400f-8deb-4e1c-8f00-36877e085317/pipeline.log\">pipeline</a>"]},{"id":"e73bb52e-75e2-48b9-9442-6331e686606d","name":"CentOS Stream 10 - 1.26","status":"complete","outcome":"passed","runTime":449.429254,"created":"2025-09-12T10:14:49.412643","updated":"2025-09-12T10:14:49.412649","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e73bb52e-75e2-48b9-9442-6331e686606d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e73bb52e-75e2-48b9-9442-6331e686606d/pipeline.log\">pipeline</a>"]},{"id":"68a97f1a-31c2-4390-9daa-b9b3ef15bdb8","name":"RHEL10 - 1.26","status":"complete","outcome":"passed","runTime":708.49152,"created":"2025-09-12T10:19:29.010948","updated":"2025-09-12T10:19:29.010954","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/68a97f1a-31c2-4390-9daa-b9b3ef15bdb8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/68a97f1a-31c2-4390-9daa-b9b3ef15bdb8/pipeline.log\">pipeline</a>"]},{"id":"c5a9fff9-f514-42a1-8ac6-ac8e8ff0a57a","name":"CentOS Stream 9 - 1.24","status":"complete","outcome":"passed","runTime":613.489383,"created":"2025-09-12T10:11:07.542332","updated":"2025-09-12T10:11:07.542340","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c5a9fff9-f514-42a1-8ac6-ac8e8ff0a57a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c5a9fff9-f514-42a1-8ac6-ac8e8ff0a57a/pipeline.log\">pipeline</a>"]},{"id":"b0f42ed2-54dd-4881-8e2b-226ec6035761","name":"RHEL8 - 1.24","status":"complete","outcome":"passed","runTime":858.426697,"created":"2025-09-12T10:06:41.525376","updated":"2025-09-12T10:06:41.525382","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b0f42ed2-54dd-4881-8e2b-226ec6035761\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b0f42ed2-54dd-4881-8e2b-226ec6035761/pipeline.log\">pipeline</a>"]},{"id":"67450fcd-6a2c-40dc-ac47-7c9788c17979","name":"RHEL9 - 1.22","status":"complete","outcome":"passed","runTime":1127.809937,"created":"2025-09-12T10:31:48.957808","updated":"2025-09-12T10:31:48.957816","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67450fcd-6a2c-40dc-ac47-7c9788c17979\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67450fcd-6a2c-40dc-ac47-7c9788c17979/pipeline.log\">pipeline</a>"]},{"id":"d332d0aa-c4f0-4a64-90d1-57eb8878c155","name":"RHEL9 - Unsubscribed host - 1.22","status":"complete","outcome":"passed","runTime":1006.817633,"created":"2025-09-12T10:24:08.108767","updated":"2025-09-12T10:24:08.108772","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d332d0aa-c4f0-4a64-90d1-57eb8878c155\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d332d0aa-c4f0-4a64-90d1-57eb8878c155/pipeline.log\">pipeline</a>"]},{"id":"63d0d46b-2313-4260-8253-93da7e59872a","name":"RHEL8 - 1.22","status":"complete","outcome":"passed","runTime":971.172575,"created":"2025-09-12T10:24:03.415213","updated":"2025-09-12T10:24:03.415218","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/63d0d46b-2313-4260-8253-93da7e59872a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/63d0d46b-2313-4260-8253-93da7e59872a/pipeline.log\">pipeline</a>"]},{"id":"9b98bd4b-8ade-4e2e-bf68-152722fb869b","name":"RHEL9 - 1.26","status":"complete","outcome":"passed","runTime":1091.526835,"created":"2025-09-12T09:59:19.623786","updated":"2025-09-12T09:59:19.623793","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b98bd4b-8ade-4e2e-bf68-152722fb869b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b98bd4b-8ade-4e2e-bf68-152722fb869b/pipeline.log\">pipeline</a>"]},{"id":"8ffc5b0a-7016-400e-9611-76ba44cad62b","name":"RHEL9 - Unsubscribed host - 1.20","status":"complete","outcome":"passed","runTime":1090.099141,"created":"2025-09-12T10:16:14.081995","updated":"2025-09-12T10:16:14.082001","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ffc5b0a-7016-400e-9611-76ba44cad62b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ffc5b0a-7016-400e-9611-76ba44cad62b/pipeline.log\">pipeline</a>"]},{"id":"f6b12c6a-d6eb-4f5a-98d9-dc8d0a6dbdc3","name":"RHEL9 - Unsubscribed host - 1.26","status":"complete","outcome":"passed","runTime":1001.00221,"created":"2025-09-12T10:06:55.135749","updated":"2025-09-12T10:06:55.135756","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6b12c6a-d6eb-4f5a-98d9-dc8d0a6dbdc3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6b12c6a-d6eb-4f5a-98d9-dc8d0a6dbdc3/pipeline.log\">pipeline</a>"]}]} -->