### PR TITLE
Make CentOS ImageStream json actually based on CentOS containers

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -13,15 +13,15 @@
     https://github.com/sclorg/nginx-container/blob/master/APP_VERSION/README.md.
   imagestream_files:
   - filename: nginx-centos.json
-    latest: "1.26-ubi9"
+    latest: "1.26-el9"
     distros:
-      - name: UBI 8
-        app_versions: ["1.22", "1.24"]
+      - name: CentOS Stream 8
+        app_versions: ["1.24"]
 
-      - name: UBI 9
+      - name: CentOS Stream 9
         app_versions: ["1.20", "1.22", "1.24", "1.26"]
 
-      - name: UBI 10
+      - name: CentOS Stream 10
         app_versions: ["1.26"]
 
   - filename: nginx-rhel.json

--- a/imagestreams/nginx-centos.json
+++ b/imagestreams/nginx-centos.json
@@ -10,30 +10,11 @@
   "spec": {
     "tags": [
       {
-        "name": "1.22-ubi8",
+        "name": "1.24-el8",
         "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 8)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (CentOS Stream 8)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
-          "iconClass": "icon-nginx",
-          "tags": "builder,nginx",
-          "version": "1.22",
-          "sampleRepo": "https://github.com/sclorg/nginx-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/nginx-122:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "1.24-ubi8",
-        "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.24",
@@ -41,18 +22,18 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/nginx-124:latest"
+          "name": "quay.io/sclorg/nginx-124-c8s:latest"
         },
         "referencePolicy": {
           "type": "Local"
         }
       },
       {
-        "name": "1.20-ubi9",
+        "name": "1.20-el9",
         "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (UBI 9)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.20 (CentOS Stream 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.20/README.md.",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.20",
@@ -60,18 +41,18 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi9/nginx-120:latest"
+          "name": "quay.io/sclorg/nginx-120-c9s:latest"
         },
         "referencePolicy": {
           "type": "Local"
         }
       },
       {
-        "name": "1.22-ubi9",
+        "name": "1.22-el9",
         "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (UBI 9)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.22 (CentOS Stream 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.22/README.md.",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.22",
@@ -79,18 +60,18 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi9/nginx-122:latest"
+          "name": "quay.io/sclorg/nginx-122-c9s:latest"
         },
         "referencePolicy": {
           "type": "Local"
         }
       },
       {
-        "name": "1.24-ubi9",
+        "name": "1.24-el9",
         "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (UBI 9)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.24 (CentOS Stream 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.24/README.md.",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.24",
@@ -98,18 +79,18 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi9/nginx-124:latest"
+          "name": "quay.io/sclorg/nginx-124-c9s:latest"
         },
         "referencePolicy": {
           "type": "Local"
         }
       },
       {
-        "name": "1.26-ubi9",
+        "name": "1.26-el9",
         "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.26 (UBI 9)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.26 (CentOS Stream 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.26",
@@ -117,18 +98,18 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi9/nginx-126:latest"
+          "name": "quay.io/sclorg/nginx-126-c9s:latest"
         },
         "referencePolicy": {
           "type": "Local"
         }
       },
       {
-        "name": "1.26-ubi10",
+        "name": "1.26-el10",
         "annotations": {
-          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.26 (UBI 10)",
+          "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.26 (CentOS Stream 10)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.26",
@@ -136,7 +117,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi10/nginx-126:latest"
+          "name": "quay.io/sclorg/nginx-126-c10s:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -147,7 +128,7 @@
         "annotations": {
           "openshift.io/display-name": "Nginx HTTP server and a reverse proxy 1.26 (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "description": "Build and serve static content via Nginx HTTP Server and a reverse proxy (nginx) on CentOS Stream 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/nginx-container/blob/master/1.26/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
           "iconClass": "icon-nginx",
           "tags": "builder,nginx",
           "version": "1.26",
@@ -155,7 +136,7 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "1.26-ubi9"
+          "name": "1.26-el9"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
It seems something went wrong when creating the file `imagestreams\nginx-centos.json` since they point to the UBI images instead of the images produced based off CentOS Stream. This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched nginx ImageStream base images from UBI to CentOS Stream and updated source image references.
  * Renamed image tags from `*-ubi*` to `*-el*` (e.g., `1.26-ubi9` → `1.26-el9`) and set the "latest" tag to `1.26-el9`.
  * Renamed distro labels to "CentOS Stream 8/9/10"; CentOS Stream 8 now lists only `1.24`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- issue-commentator = {"comment-id":"4178280178"} -->