### PR TITLE
Compare nginx version against the major OS version

### DIFF
--- a/1.20/test/test_container_sizes.py
+++ b/1.20/test/test_container_sizes.py
@@ -1,0 +1,1 @@
+../../test/test_container_sizes.py

--- a/1.22/test/test_container_sizes.py
+++ b/1.22/test/test_container_sizes.py
@@ -1,0 +1,1 @@
+../../test/test_container_sizes.py

--- a/1.24/test/test-lib-nginx.sh
+++ b/1.24/test/test-lib-nginx.sh
@@ -1,1 +1,0 @@
-../../test/test-lib-nginx.sh

--- a/1.24/test/test-lib-openshift.sh
+++ b/1.24/test/test-lib-openshift.sh
@@ -1,1 +1,0 @@
-../../common/test-lib-openshift.sh

--- a/1.24/test/test-lib-remote-openshift.sh
+++ b/1.24/test/test-lib-remote-openshift.sh
@@ -1,1 +1,0 @@
-../../common/test-lib-remote-openshift.sh

--- a/1.24/test/test-openshift.yaml
+++ b/1.24/test/test-openshift.yaml
@@ -1,1 +1,0 @@
-../../common/test-openshift.yaml

--- a/1.24/test/test_container_sizes.py
+++ b/1.24/test/test_container_sizes.py
@@ -1,0 +1,1 @@
+../../test/test_container_sizes.py

--- a/1.26/test/test_container_sizes.py
+++ b/1.26/test/test_container_sizes.py
@@ -1,0 +1,1 @@
+../../test/test_container_sizes.py

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,9 +17,16 @@ TAGS = {
 }
 
 Vars = namedtuple(
-    "Vars", [
-        "OS", "TAG", "VERSION", "IMAGE_NAME", "VERSION_NO_MICRO", "SHORT_VERSION", "TEST_DIR"
-    ]
+    "Vars",
+    [
+        "OS",
+        "TAG",
+        "VERSION",
+        "IMAGE_NAME",
+        "VERSION_NO_MICRO",
+        "SHORT_VERSION",
+        "TEST_DIR",
+    ],
 )
 OS = os.getenv("TARGET").lower()
 VERSION = os.getenv("VERSION")
@@ -37,5 +44,16 @@ VARS = Vars(
 
 
 def skip_clear_env_tests():
+    """
+    Skip the test if the OS is RHEL 8 and the version is 8.2.
+    """
     if VARS.OS == "rhel8" and VERSION == "8.2":
         skip(f"Skipping clear env tests for {VARS.VERSION} on {VARS.OS}.")
+
+
+def skip_if_version_not_minimal():
+    """
+    Skip the test if the version is not minimal.
+    """
+    if "minimal" not in VARS.VERSION:
+        skip("Skipping container size comparison for non-minimal version.")

--- a/test/test_container_basics.py
+++ b/test/test_container_basics.py
@@ -8,11 +8,20 @@ from conftest import VARS
 
 
 class TestNginxContainer:
+    """
+    Test container basics
+    """
 
     def setup_method(self):
+        """
+        Setup method
+        """
         self.app = ContainerTestLib(image_name=VARS.IMAGE_NAME, s2i_image=True)
 
     def teardown_method(self):
+        """
+        Teardown method
+        """
         self.app.cleanup()
 
     def test_run_s2i_usage(self):
@@ -26,41 +35,46 @@ class TestNginxContainer:
         """
         Test if container is runnable
         """
-        assert PodmanCLIWrapper.call_podman_command(
-            cmd=f"run --rm {VARS.IMAGE_NAME} &>/dev/null",
-            return_output=False
-        ) == 0
+        assert (
+            PodmanCLIWrapper.call_podman_command(
+                cmd=f"run --rm {VARS.IMAGE_NAME} &>/dev/null", return_output=False
+            )
+            == 0
+        )
 
     def test_scl_usage(self):
         """
         Test if nginx -v returns proper output
         """
 
-        assert f"nginx/{VARS.VERSION_NO_MICRO}" in PodmanCLIWrapper.podman_run_command_and_remove(
-            cid_file_name=VARS.IMAGE_NAME,
-            cmd="nginx -v"
+        assert (
+            f"nginx/{VARS.VERSION_NO_MICRO}"
+            in PodmanCLIWrapper.podman_run_command_and_remove(
+                cid_file_name=VARS.IMAGE_NAME, cmd="nginx -v"
+            )
         )
 
-    @pytest.mark.parametrize(
-        "dockerfile",
-        [
-            "Dockerfile",
-            "Dockerfile.s2i"
-        ]
-    )
+    @pytest.mark.parametrize("dockerfile", ["Dockerfile", "Dockerfile.s2i"])
     def test_dockerfiles(self, dockerfile):
         """
         Test if building nginx-container based on
         examples/Dockerfile works
         """
-        dp = DockerfileProcessor(dockerfile_path=f"{VARS.TEST_DIR}/examples/{dockerfile}")
-        dp.update_env_in_dockerfile(version=VARS.VERSION_NO_MICRO, what_to_replace="ENV NGINX_VERSION")
-        dp.update_variable_in_dockerfile(version=VARS.VERSION_NO_MICRO, variable="NGINX_VERSION")
+        dp = DockerfileProcessor(
+            dockerfile_path=f"{VARS.TEST_DIR}/examples/{dockerfile}"
+        )
+        dp.update_env_in_dockerfile(
+            version=VARS.VERSION_NO_MICRO, what_to_replace="ENV NGINX_VERSION"
+        )
+        dp.update_variable_in_dockerfile(
+            version=VARS.VERSION_NO_MICRO, variable="NGINX_VERSION"
+        )
         new_docker_file = dp.create_temp_dockerfile()
 
         assert self.app.build_test_container(
-            dockerfile=new_docker_file, app_url="https://github.com/sclorg/nginx-container.git",
-            app_dir="nginx-container"
+            dockerfile=new_docker_file,
+            app_url="https://github.com/sclorg/nginx-container.git",
+            app_dir="nginx-container",
         )
         assert self.app.test_app_dockerfile()
         cip = self.app.get_cip()

--- a/test/test_container_sizes.py
+++ b/test/test_container_sizes.py
@@ -29,9 +29,11 @@ class TestNginxContainerSizes:
         Test the size of the Nginx container against the
         already published container images.
         """
+        if not VARS.OS.startswith("rhel"):
+            pytest.skip("Skipping container size comparison for non-RHEL OS.")
         published_image_name = get_public_image_name(
             os_name=get_previous_os_version(VARS.OS),
-            base_image_name="postgresql",
+            base_image_name="nginx",
             version=VARS.VERSION,
             stage_registry=True,
         )

--- a/test/test_container_sizes.py
+++ b/test/test_container_sizes.py
@@ -1,0 +1,50 @@
+import pytest
+
+from container_ci_suite.container_lib import ContainerTestLib
+from container_ci_suite.compare_images import ContainerCompareClass
+from container_ci_suite.utils import get_public_image_name, get_previous_os_version
+
+from conftest import VARS
+
+
+class TestNginxContainerSizes:
+    """
+    Test container sizes
+    """
+
+    def setup_method(self):
+        """
+        Setup method
+        """
+        self.app = ContainerTestLib(image_name=VARS.IMAGE_NAME, s2i_image=True)
+
+    def teardown_method(self):
+        """
+        Teardown method
+        """
+        self.app.cleanup()
+
+    def test_compare_container_sizes(self):
+        """
+        Test the size of the Nginx container against the
+        already published container images.
+        """
+        published_image_name = get_public_image_name(
+            os_name=get_previous_os_version(VARS.OS),
+            base_image_name="postgresql",
+            version=VARS.VERSION,
+            stage_registry=True,
+        )
+        is_less_uncopressed = ContainerCompareClass.is_uncompressed_image_smaller(
+            built_image_name=VARS.IMAGE_NAME,
+            published_image=published_image_name,
+        )
+        is_less_compressed = ContainerCompareClass.is_compressed_image_smaller(
+            built_image_name=VARS.IMAGE_NAME,
+            published_image_name=published_image_name,
+        )
+        if not is_less_uncopressed or not is_less_compressed:
+            pytest.skip(
+                f"Container size is not less than the published image {published_image_name}. "
+                f"Uncompressed image size: {is_less_uncopressed}, Compressed image size: {is_less_compressed}"
+            )

--- a/test/test_container_sizes.py
+++ b/test/test_container_sizes.py
@@ -4,7 +4,7 @@ from container_ci_suite.container_lib import ContainerTestLib
 from container_ci_suite.compare_images import ContainerCompareClass
 from container_ci_suite.utils import get_public_image_name, get_previous_os_version
 
-from conftest import VARS
+from conftest import VARS, skip_if_version_not_minimal
 
 
 class TestNginxContainerSizes:
@@ -29,6 +29,7 @@ class TestNginxContainerSizes:
         Test the size of the Nginx container against the
         already published container images.
         """
+        skip_if_version_not_minimal()
         if not VARS.OS.startswith("rhel"):
             pytest.skip("Skipping container size comparison for non-RHEL OS.")
         published_image_name = get_public_image_name(


### PR DESCRIPTION
Compare nginx version against the major OS version.

In case image is less then previous major OS version, then the test passed.

In case image is higher then previous major OS version, then the test is skipped.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4279802571"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added container size comparison tests to verify built images are smaller than published baselines and skip appropriately for non-applicable versions.
  * Improved test documentation, reorganized parametrization and formatting for clearer, more maintainable tests.
  * Added a helper to skip tests unless running a "minimal" version.

* **Chores**
  * Cleaned up version-specific test entry points, adding and removing lightweight wrappers to align test discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4281010412","data":[{"id":"93a00961-31b3-4cf5-9230-33916a76809d","name":"CentOS Stream 10 - PyTest - 1.26","status":"complete","outcome":"passed","runTime":522.517962,"created":"2026-04-21T08:57:38.736068","updated":"2026-04-21T08:57:38.736074","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/93a00961-31b3-4cf5-9230-33916a76809d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/93a00961-31b3-4cf5-9230-33916a76809d/pipeline.log\">pipeline</a>"]},{"id":"ebcf5a71-1e45-4fa0-a1f3-241b5bb2aab1","name":"CentOS Stream 9 - PyTest - 1.24","status":"complete","outcome":"passed","runTime":548.657825,"created":"2026-04-21T08:28:35.077848","updated":"2026-04-21T08:28:35.077855","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ebcf5a71-1e45-4fa0-a1f3-241b5bb2aab1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ebcf5a71-1e45-4fa0-a1f3-241b5bb2aab1/pipeline.log\">pipeline</a>"]},{"id":"221b194b-d8f4-4995-a07f-ab504b6df0ae","name":"Fedora - PyTest - 1.26","status":"complete","outcome":"passed","runTime":270.227709,"created":"2026-04-21T08:24:59.524609","updated":"2026-04-21T08:24:59.524616","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/221b194b-d8f4-4995-a07f-ab504b6df0ae\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/221b194b-d8f4-4995-a07f-ab504b6df0ae/pipeline.log\">pipeline</a>"]},{"id":"a3262570-cde8-44e0-b3a9-01c869a7516b","name":"CentOS Stream 9 - PyTest - 1.22-micro","status":"complete","outcome":"passed","runTime":601.106528,"created":"2026-04-21T08:59:08.704655","updated":"2026-04-21T08:59:08.704661","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a3262570-cde8-44e0-b3a9-01c869a7516b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a3262570-cde8-44e0-b3a9-01c869a7516b/pipeline.log\">pipeline</a>"]},{"id":"3a7e1316-4a74-4cbc-927a-9f768119990d","name":"RHEL9 - PyTest - 1.26","status":"complete","outcome":"passed","runTime":1177.399993,"created":"2026-04-21T07:50:07.304506","updated":"2026-04-21T07:50:07.304526","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a7e1316-4a74-4cbc-927a-9f768119990d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a7e1316-4a74-4cbc-927a-9f768119990d/pipeline.log\">pipeline</a>"]},{"id":"11a5754e-52c2-4eef-b988-1c579fa9f7aa","name":"RHEL8 - PyTest - 1.24","status":"complete","outcome":"passed","runTime":762.237115,"created":"2026-04-21T07:49:11.451418","updated":"2026-04-21T07:49:11.451423","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/11a5754e-52c2-4eef-b988-1c579fa9f7aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/11a5754e-52c2-4eef-b988-1c579fa9f7aa/pipeline.log\">pipeline</a>"]},{"id":"28442adb-a50d-41d4-9ce4-bca948d0c38c","name":"RHEL9 - Unsubscribed host - PyTest - 1.20","status":"complete","outcome":"passed","runTime":1401.625812,"created":"2026-04-21T08:34:39.736465","updated":"2026-04-21T08:34:39.736471","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/28442adb-a50d-41d4-9ce4-bca948d0c38c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/28442adb-a50d-41d4-9ce4-bca948d0c38c/pipeline.log\">pipeline</a>"]},{"id":"689beb42-633a-40b9-a982-7a4444c126b1","name":"RHEL9 - Unsubscribed host - PyTest - 1.22","status":"complete","outcome":"passed","runTime":972.939935,"created":"2026-04-21T08:49:48.418367","updated":"2026-04-21T08:49:48.418377","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/689beb42-633a-40b9-a982-7a4444c126b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/689beb42-633a-40b9-a982-7a4444c126b1/pipeline.log\">pipeline</a>"]},{"id":"58322a1c-f2c5-4f5a-b770-77c1d7e25f62","name":"CentOS Stream 9 - PyTest - 1.26","status":"complete","outcome":"passed","runTime":554.193559,"created":"2026-04-21T08:24:16.635747","updated":"2026-04-21T08:24:16.635754","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/58322a1c-f2c5-4f5a-b770-77c1d7e25f62\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/58322a1c-f2c5-4f5a-b770-77c1d7e25f62/pipeline.log\">pipeline</a>"]},{"id":"9c2ace3f-0837-4949-896f-31abca0a6a77","name":"RHEL9 - PyTest - 1.24","status":"complete","outcome":"passed","runTime":1119.382345,"created":"2026-04-21T08:14:43.771505","updated":"2026-04-21T08:14:43.771512","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c2ace3f-0837-4949-896f-31abca0a6a77\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c2ace3f-0837-4949-896f-31abca0a6a77/pipeline.log\">pipeline</a>"]},{"id":"7776ca01-0700-4fe4-8a34-dcfd46f9456b","name":"RHEL9 - PyTest - 1.20","status":"complete","outcome":"passed","runTime":1158.380076,"created":"2026-04-21T08:43:44.223010","updated":"2026-04-21T08:43:44.223019","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7776ca01-0700-4fe4-8a34-dcfd46f9456b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7776ca01-0700-4fe4-8a34-dcfd46f9456b/pipeline.log\">pipeline</a>"]},{"id":"cb727744-1c14-42c0-89dd-5714311800a9","name":"RHEL9 - Unsubscribed host - PyTest - 1.26","status":"complete","outcome":"passed","runTime":1027.045633,"created":"2026-04-21T08:30:25.105387","updated":"2026-04-21T08:30:25.105399","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cb727744-1c14-42c0-89dd-5714311800a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cb727744-1c14-42c0-89dd-5714311800a9/pipeline.log\">pipeline</a>"]},{"id":"ccbfaa52-db1e-42c2-adad-5d100470fa58","name":"RHEL9 - Unsubscribed host - PyTest - 1.24","runTime":1033.781917,"created":"2026-04-21T09:01:02.910937","updated":"2026-04-21T09:01:02.910946","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ccbfaa52-db1e-42c2-adad-5d100470fa58\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ccbfaa52-db1e-42c2-adad-5d100470fa58/pipeline.log\">pipeline</a>"]},{"id":"ee436872-5851-414d-b77d-99532db6fcbe","name":"RHEL8 - PyTest - 1.22-micro","status":"complete","outcome":"passed","runTime":794.123562,"created":"2026-04-21T08:43:12.563719","updated":"2026-04-21T08:43:12.563729","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee436872-5851-414d-b77d-99532db6fcbe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee436872-5851-414d-b77d-99532db6fcbe/pipeline.log\">pipeline</a>"]},{"id":"cd527911-5e64-4609-8ff6-abd4ed2281a8","name":"RHEL10 - PyTest - 1.26","status":"complete","outcome":"error","runTime":869.577661,"created":"2026-04-21T07:53:32.121896","updated":"2026-04-21T07:53:32.121905","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd527911-5e64-4609-8ff6-abd4ed2281a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd527911-5e64-4609-8ff6-abd4ed2281a8/pipeline.log\">pipeline</a>"]},{"id":"78301d62-481f-4df7-ba01-d73eaf486ef8","name":"RHEL8 - PyTest - 1.22","status":"complete","outcome":"passed","runTime":804.728757,"created":"2026-04-21T08:10:28.046719","updated":"2026-04-21T08:10:28.046724","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/78301d62-481f-4df7-ba01-d73eaf486ef8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/78301d62-481f-4df7-ba01-d73eaf486ef8/pipeline.log\">pipeline</a>"]},{"id":"12b16e60-8092-4e53-bf91-a45b044cdae6","name":"RHEL10 - Unsubscribed host - PyTest - 1.26","status":"complete","outcome":"passed","runTime":815.236026,"created":"2026-04-21T08:51:38.898584","updated":"2026-04-21T08:51:38.898592","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/12b16e60-8092-4e53-bf91-a45b044cdae6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/12b16e60-8092-4e53-bf91-a45b044cdae6/pipeline.log\">pipeline</a>"]},{"id":"b2645d81-6b29-4a5a-9089-b20bae7c09ac","name":"RHEL9 - PyTest - 1.22","status":"complete","outcome":"passed","runTime":1063.854369,"created":"2026-04-21T08:12:37.479408","updated":"2026-04-21T08:12:37.479415","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2645d81-6b29-4a5a-9089-b20bae7c09ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2645d81-6b29-4a5a-9089-b20bae7c09ac/pipeline.log\">pipeline</a>"]}]} -->