### PR TITLE
Compare sizes only for RHEL 10 and higher. No less OS

### DIFF
--- a/test/test_container_sizes.py
+++ b/test/test_container_sizes.py
@@ -32,8 +32,11 @@ class TestNginxContainerSizes:
         skip_if_version_not_minimal()
         if not VARS.OS.startswith("rhel"):
             pytest.skip("Skipping container size comparison for non-RHEL OS.")
+        previous_os_version = get_previous_os_version(os_name=VARS.OS)
+        if previous_os_version in ["rhel7", "rhel8", "rhel9"]:
+            pytest.skip("Skipping container size comparison for RHEL 7, 8 and 9.")
         published_image_name = get_public_image_name(
-            os_name=get_previous_os_version(VARS.OS),
+            os_name=previous_os_version,
             base_image_name="nginx",
             version=VARS.VERSION,
             stage_registry=True,


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored container size comparison tests to skip RHEL 7, 8, and 9 versions for improved test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- issue-commentator = {"comment-id":"4287813740"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4288234043","data":[{"id":"b5561ff0-6327-4b5d-8ec6-63e418c443de","name":"Fedora - PyTest - 1.26","status":"complete","outcome":"passed","runTime":310.010294,"created":"2026-04-21T11:34:55.507651","updated":"2026-04-21T11:34:55.507659","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b5561ff0-6327-4b5d-8ec6-63e418c443de\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b5561ff0-6327-4b5d-8ec6-63e418c443de/pipeline.log\">pipeline</a>"]},{"id":"7a5b87b5-88de-4df2-bf7d-b3f595967d80","name":"CentOS Stream 9 - PyTest - 1.26","status":"complete","outcome":"passed","runTime":572.206224,"created":"2026-04-21T11:34:57.918254","updated":"2026-04-21T11:34:57.918264","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7a5b87b5-88de-4df2-bf7d-b3f595967d80\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7a5b87b5-88de-4df2-bf7d-b3f595967d80/pipeline.log\">pipeline</a>"]},{"id":"5bfd2446-499f-45a5-ad38-8693207fd69d","name":"CentOS Stream 9 - PyTest - 1.24","status":"complete","outcome":"passed","runTime":581.539165,"created":"2026-04-21T11:34:57.892467","updated":"2026-04-21T11:34:57.892475","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5bfd2446-499f-45a5-ad38-8693207fd69d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5bfd2446-499f-45a5-ad38-8693207fd69d/pipeline.log\">pipeline</a>"]},{"id":"e48bd695-6375-4bf6-ab82-f456793efec0","name":"CentOS Stream 10 - PyTest - 1.26","status":"complete","outcome":"passed","runTime":547.126453,"created":"2026-04-21T11:34:57.381531","updated":"2026-04-21T11:34:57.381540","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e48bd695-6375-4bf6-ab82-f456793efec0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e48bd695-6375-4bf6-ab82-f456793efec0/pipeline.log\">pipeline</a>"]},{"id":"fdd87705-6f23-4ffb-bc35-3c187bc73a82","name":"RHEL8 - PyTest - 1.22","status":"complete","outcome":"passed","runTime":1004.289503,"created":"2026-04-21T11:34:57.454204","updated":"2026-04-21T11:34:57.454210","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdd87705-6f23-4ffb-bc35-3c187bc73a82\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdd87705-6f23-4ffb-bc35-3c187bc73a82/pipeline.log\">pipeline</a>"]},{"id":"563ef1e3-26ba-4392-b7f3-ced49a9166c0","name":"RHEL8 - PyTest - 1.22-micro","status":"complete","outcome":"passed","runTime":1020.454837,"created":"2026-04-21T11:34:57.673080","updated":"2026-04-21T11:34:57.673091","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/563ef1e3-26ba-4392-b7f3-ced49a9166c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/563ef1e3-26ba-4392-b7f3-ced49a9166c0/pipeline.log\">pipeline</a>"]},{"id":"3cb6a484-9a7c-4e12-b159-add80f13c411","name":"RHEL8 - PyTest - 1.24","status":"complete","outcome":"passed","runTime":1003.195344,"created":"2026-04-21T11:34:58.670354","updated":"2026-04-21T11:34:58.670365","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cb6a484-9a7c-4e12-b159-add80f13c411\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cb6a484-9a7c-4e12-b159-add80f13c411/pipeline.log\">pipeline</a>"]},{"id":"6c6f0789-7ad6-4ef2-b5fe-d2d11b3bfa62","name":"RHEL10 - PyTest - 1.26","runTime":944.080467,"created":"2026-04-21T12:13:48.552418","updated":"2026-04-21T12:13:48.552425","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c6f0789-7ad6-4ef2-b5fe-d2d11b3bfa62\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c6f0789-7ad6-4ef2-b5fe-d2d11b3bfa62/pipeline.log\">pipeline</a>"]},{"id":"2f1b6cb5-cc58-4086-a213-c9e5a02c9147","name":"RHEL9 - Unsubscribed host - PyTest - 1.20","status":"complete","outcome":"passed","runTime":1294.498645,"created":"2026-04-21T11:34:55.645485","updated":"2026-04-21T11:34:55.645492","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f1b6cb5-cc58-4086-a213-c9e5a02c9147\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f1b6cb5-cc58-4086-a213-c9e5a02c9147/pipeline.log\">pipeline</a>"]},{"id":"01608166-20ee-48f9-b06a-adb1e5ace171","name":"RHEL9 - Unsubscribed host - PyTest - 1.26","status":"complete","outcome":"passed","runTime":1322.465161,"created":"2026-04-21T11:34:57.552827","updated":"2026-04-21T11:34:57.552834","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01608166-20ee-48f9-b06a-adb1e5ace171\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01608166-20ee-48f9-b06a-adb1e5ace171/pipeline.log\">pipeline</a>"]},{"id":"ac00c60f-8b17-4a32-afe3-e82340105a9a","name":"RHEL9 - Unsubscribed host - PyTest - 1.22","status":"complete","outcome":"passed","runTime":1351.869712,"created":"2026-04-21T11:34:55.551357","updated":"2026-04-21T11:34:55.551364","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac00c60f-8b17-4a32-afe3-e82340105a9a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac00c60f-8b17-4a32-afe3-e82340105a9a/pipeline.log\">pipeline</a>"]},{"id":"acc78aa6-7c86-466b-96bf-d4b2bd2dde2e","name":"RHEL9 - Unsubscribed host - PyTest - 1.24","status":"complete","outcome":"passed","runTime":1355.653168,"created":"2026-04-21T11:34:55.463876","updated":"2026-04-21T11:34:55.463882","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/acc78aa6-7c86-466b-96bf-d4b2bd2dde2e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/acc78aa6-7c86-466b-96bf-d4b2bd2dde2e/pipeline.log\">pipeline</a>"]},{"id":"e580c6d3-a8ae-45d3-888c-0f1f0e3b79b2","name":"RHEL9 - PyTest - 1.26","status":"complete","outcome":"passed","runTime":1439.834709,"created":"2026-04-21T11:34:55.946048","updated":"2026-04-21T11:34:55.946054","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e580c6d3-a8ae-45d3-888c-0f1f0e3b79b2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e580c6d3-a8ae-45d3-888c-0f1f0e3b79b2/pipeline.log\">pipeline</a>"]},{"id":"d5884951-fff3-42cd-8874-e35d39949316","name":"RHEL9 - PyTest - 1.20","status":"complete","outcome":"passed","runTime":1428.387326,"created":"2026-04-21T11:34:57.560338","updated":"2026-04-21T11:34:57.560346","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d5884951-fff3-42cd-8874-e35d39949316\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d5884951-fff3-42cd-8874-e35d39949316/pipeline.log\">pipeline</a>"]},{"id":"fb074cf2-7583-4ede-962f-37ee64315d87","name":"RHEL9 - PyTest - 1.22","status":"complete","outcome":"passed","runTime":1454.857252,"created":"2026-04-21T11:34:56.829588","updated":"2026-04-21T11:34:56.829600","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb074cf2-7583-4ede-962f-37ee64315d87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fb074cf2-7583-4ede-962f-37ee64315d87/pipeline.log\">pipeline</a>"]}]} -->